### PR TITLE
Scaffold Prosite builder foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+/node_modules
+/.next
+/out
+.env*
+.DS_Store
+*.log
+
+# generated
+.next-env.d.ts

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "prosite",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@headlessui/react": "^2.1.5",
+    "@heroicons/react": "^2.1.5",
+    "clsx": "^2.1.0",
+    "mongodb": "^6.6.2",
+    "mongoose": "^8.3.2",
+    "next": "15.0.0",
+    "next-auth": "^5.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "stripe": "^14.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "15.0.0",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,31 @@
+import NextAuth from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+
+const handler = NextAuth({
+  providers: [
+    Credentials({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "email", placeholder: "you@example.com" },
+        password: { label: "Password", type: "password" }
+      },
+      async authorize(credentials) {
+        if (!credentials?.email) {
+          return null;
+        }
+
+        // TODO: replace with secure credential check via MongoDB
+        return {
+          id: "demo-user",
+          name: "Demo User",
+          email: credentials.email
+        };
+      }
+    })
+  ],
+  session: {
+    strategy: "jwt"
+  }
+});
+
+export { handler as GET, handler as POST };

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+
+const stripeSecret = process.env.STRIPE_SECRET_KEY;
+const stripe = stripeSecret ? new Stripe(stripeSecret, { apiVersion: "2023-10-16" }) : null;
+
+export async function POST(request: Request) {
+  if (!stripe) {
+    return NextResponse.json({ error: "Stripe is not configured" }, { status: 500 });
+  }
+
+  const { templateId } = await request.json();
+
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      payment_method_types: ["card"],
+      line_items: [
+        {
+          price_data: {
+            currency: "usd",
+            product_data: {
+              name: `Prosite Subscription - ${templateId}`
+            },
+            recurring: { interval: "month" },
+            unit_amount: 2900
+          },
+          quantity: 1
+        }
+      ],
+      success_url: `${process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"}/success`,
+      cancel_url: `${process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"}/builder/checkout`
+    });
+
+    return NextResponse.json({ checkoutUrl: session.url });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Failed to create checkout session" }, { status: 500 });
+  }
+}

--- a/src/app/api/websites/route.ts
+++ b/src/app/api/websites/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { loadTemplateAssets } from "@/lib/templates";
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const templateId = searchParams.get("templateId");
+
+  if (!templateId) {
+    return NextResponse.json({ error: "templateId is required" }, { status: 400 });
+  }
+
+  try {
+    const assets = await loadTemplateAssets(templateId);
+    return NextResponse.json(assets);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Unable to load template" }, { status: 404 });
+  }
+}

--- a/src/app/builder/BuilderRoot.tsx
+++ b/src/app/builder/BuilderRoot.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { BuilderProvider } from "@/context/BuilderContext";
+import { ProgressBar } from "@/components/builder/ProgressBar";
+import { DeviceControls } from "@/components/builder/DeviceControls";
+import { Sidebar } from "@/components/builder/Sidebar";
+import { WebsitePreview } from "@/components/builder/WebsitePreview";
+
+const steps = [
+  { label: "Theme", href: "/builder/theme" },
+  { label: "Content", href: "/builder/content" },
+  { label: "Checkout", href: "/builder/checkout" }
+];
+
+type BuilderRootProps = {
+  children: React.ReactNode;
+};
+
+export default function BuilderRoot({ children }: BuilderRootProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const currentStep = useMemo(() => {
+    const index = steps.findIndex((step) => pathname.startsWith(step.href));
+    return index === -1 ? 0 : index;
+  }, [pathname]);
+
+  return (
+    <BuilderProvider>
+      <div className="flex min-h-screen flex-col bg-builder-background text-slate-100">
+        <header className="border-b border-slate-800/60 bg-builder-surface/70 backdrop-blur">
+          <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
+            <div>
+              <h1 className="text-xl font-semibold">Prosite Builder</h1>
+              <p className="text-sm text-slate-400">Craft a polished web presence in three guided steps.</p>
+            </div>
+            <div className="hidden text-right sm:block">
+              <p className="text-sm font-medium text-slate-300">Need help?</p>
+              <p className="text-xs text-slate-500">Schedule a strategy call with our team.</p>
+            </div>
+          </div>
+          <ProgressBar steps={steps} activeIndex={currentStep} onStepClick={(href) => router.push(href)} />
+        </header>
+        <main className="flex flex-1 overflow-hidden">
+          <section className="flex flex-1 flex-col overflow-hidden">
+            <div className="flex items-center justify-end border-b border-slate-800/60 bg-builder-surface px-6 py-3">
+              <DeviceControls />
+            </div>
+            <div className="flex flex-1 overflow-hidden">
+              <div className="flex flex-1 flex-col overflow-hidden">
+                <WebsitePreview />
+                <div className="border-t border-slate-800/60 bg-builder-surface/60 backdrop-blur">
+                  <div className="mx-auto h-full max-h-[22rem] w-full max-w-5xl overflow-y-auto px-6 py-6">
+                    {children}
+                  </div>
+                </div>
+              </div>
+              <Sidebar steps={steps} currentIndex={currentStep} />
+            </div>
+          </section>
+        </main>
+      </div>
+    </BuilderProvider>
+  );
+}

--- a/src/app/builder/checkout/page.tsx
+++ b/src/app/builder/checkout/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState } from "react";
+import { useBuilder } from "@/context/BuilderContext";
+
+export default function CheckoutPage() {
+  const { selectedTemplate, content } = useBuilder();
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleCheckout = async () => {
+    setIsProcessing(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ templateId: selectedTemplate.id, content })
+      });
+
+      if (!response.ok) {
+        throw new Error("Unable to initialize checkout");
+      }
+
+      const data = await response.json();
+
+      if (data?.checkoutUrl) {
+        window.location.href = data.checkoutUrl;
+      }
+    } catch (exception) {
+      setError(exception instanceof Error ? exception.message : "Unexpected error");
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-3">
+        <h2 className="text-2xl font-semibold">Launch on your terms</h2>
+        <p className="text-sm text-slate-400">
+          Subscribe to unlock hosting, analytics, and ongoing support. Upgrade with additional templates anytime.
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="rounded-2xl border border-slate-800/70 bg-slate-900/40 p-6">
+          <h3 className="text-lg font-semibold">Plan summary</h3>
+          <ul className="mt-4 space-y-3 text-sm text-slate-300">
+            <li className="flex items-center justify-between">
+              <span>Template</span>
+              <span className="font-medium text-slate-100">{selectedTemplate.name}</span>
+            </li>
+            <li className="flex items-center justify-between">
+              <span>Hosting &amp; support</span>
+              <span className="font-medium text-slate-100">$29/mo</span>
+            </li>
+            <li className="flex items-center justify-between">
+              <span>Template upgrades</span>
+              <span className="font-medium text-slate-100">From $149</span>
+            </li>
+          </ul>
+        </div>
+
+        <div className="rounded-2xl border border-slate-800/70 bg-slate-900/40 p-6">
+          <h3 className="text-lg font-semibold">Before you publish</h3>
+          <ul className="mt-4 space-y-3 text-sm text-slate-300">
+            <li>Download assets or sync with your domain post-checkout.</li>
+            <li>Invite collaborators and manage permissions in your dashboard.</li>
+            <li>Schedule onboarding with our success team.</li>
+          </ul>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 rounded-2xl border border-slate-800/70 bg-slate-900/40 p-6 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-medium text-slate-200">Launch your site</p>
+          <p className="text-xs text-slate-500">Secure checkout powered by Stripe.</p>
+        </div>
+        <button
+          type="button"
+          onClick={handleCheckout}
+          disabled={isProcessing}
+          className="inline-flex items-center justify-center rounded-full bg-builder-accent px-6 py-3 text-sm font-semibold text-slate-950 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isProcessing ? "Preparing checkout..." : "Proceed to Stripe"}
+        </button>
+      </div>
+      {error ? <p className="text-sm text-rose-400">{error}</p> : null}
+    </div>
+  );
+}

--- a/src/app/builder/content/page.tsx
+++ b/src/app/builder/content/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useBuilder } from "@/context/BuilderContext";
+
+const contentFields: { key: string; label: string; helper?: string; type?: "textarea" | "email" }[] = [
+  { key: "name", label: "Headline", helper: "Displayed in the hero section." },
+  { key: "tagline", label: "Tagline", helper: "A short phrase summarizing your value." },
+  { key: "about", label: "About", helper: "Appears in the about section.", type: "textarea" },
+  { key: "resumeTitle", label: "Resume Section Title" },
+  { key: "resumeSummary", label: "Resume Summary", type: "textarea" },
+  { key: "portfolioHeading", label: "Portfolio Heading" },
+  { key: "testimonialQuote", label: "Testimonial Quote", type: "textarea" },
+  { key: "testimonialAuthor", label: "Testimonial Author" },
+  { key: "contactHeadline", label: "Contact Headline" },
+  { key: "contactEmail", label: "Contact Email", type: "email" }
+];
+
+export default function ContentPage() {
+  const { content, updateContent } = useBuilder();
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-3">
+        <h2 className="text-2xl font-semibold">Shape your story</h2>
+        <p className="text-sm text-slate-400">
+          Update copy across the template. Changes sync instantly with the live preview.
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {contentFields.map(({ key, label, helper, type }) => (
+          <label key={key} className="flex flex-col space-y-2">
+            <div className="flex items-center justify-between text-sm font-medium text-slate-300">
+              <span>{label}</span>
+              {helper ? <span className="text-xs text-slate-500">{helper}</span> : null}
+            </div>
+            {type === "textarea" ? (
+              <textarea
+                value={content[key] ?? ""}
+                onChange={(event) => updateContent({ [key]: event.target.value })}
+                rows={4}
+                className="min-h-[120px] rounded-xl border border-slate-800/70 bg-slate-900/40 px-3 py-2 text-sm text-slate-100 shadow-inner shadow-black/40 focus:border-builder-accent focus:outline-none"
+              />
+            ) : (
+              <input
+                type={type ?? "text"}
+                value={content[key] ?? ""}
+                onChange={(event) => updateContent({ [key]: event.target.value })}
+                className="rounded-xl border border-slate-800/70 bg-slate-900/40 px-3 py-2 text-sm text-slate-100 focus:border-builder-accent focus:outline-none"
+              />
+            )}
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/builder/layout.tsx
+++ b/src/app/builder/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import BuilderRoot from "./BuilderRoot";
+
+export default function BuilderLayout({ children }: { children: ReactNode }) {
+  return <BuilderRoot>{children}</BuilderRoot>;
+}

--- a/src/app/builder/theme/page.tsx
+++ b/src/app/builder/theme/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useBuilder } from "@/context/BuilderContext";
+
+const palettePresets = [
+  {
+    name: "Aurora",
+    values: {
+      primaryColor: "#38bdf8",
+      secondaryColor: "#0ea5e9",
+      accentColor: "#f472b6",
+      backgroundColor: "#020617",
+      textColor: "#e2e8f0"
+    }
+  },
+  {
+    name: "Luxe",
+    values: {
+      primaryColor: "#f59e0b",
+      secondaryColor: "#d97706",
+      accentColor: "#fde68a",
+      backgroundColor: "#0b1120",
+      textColor: "#f8fafc"
+    }
+  },
+  {
+    name: "Verdant",
+    values: {
+      primaryColor: "#34d399",
+      secondaryColor: "#10b981",
+      accentColor: "#86efac",
+      backgroundColor: "#022c22",
+      textColor: "#ecfdf5"
+    }
+  }
+];
+
+export default function ThemePage() {
+  const { theme, updateTheme, selectedTemplate } = useBuilder();
+
+  return (
+    <div className="space-y-8">
+      <div className="space-y-3">
+        <h2 className="text-2xl font-semibold">Choose your visual identity</h2>
+        <p className="text-sm text-slate-400">
+          Select a palette and fine-tune the colors to match your brand. Switch templates anytime without losing
+          progress.
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {palettePresets.map((preset) => (
+          <button
+            type="button"
+            key={preset.name}
+            onClick={() => updateTheme(preset.values)}
+            className="group rounded-2xl border border-slate-700/80 bg-slate-900/30 p-5 text-left transition hover:border-builder-accent"
+          >
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-base font-semibold text-slate-100">{preset.name}</p>
+                <p className="text-sm text-slate-400">Curated colors for modern brands.</p>
+              </div>
+              <div className="flex gap-2">
+                {Object.values(preset.values).slice(0, 3).map((value) => (
+                  <span
+                    key={value}
+                    className="h-8 w-8 rounded-full border border-white/10"
+                    style={{ backgroundColor: value }}
+                  />
+                ))}
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {Object.entries(theme).map(([key, value]) => (
+          <label key={key} className="space-y-2">
+            <div className="flex items-center justify-between text-sm font-medium text-slate-300">
+              <span className="capitalize">{key.replace(/([A-Z])/g, " $1")}</span>
+              <span className="text-xs text-slate-500">{value}</span>
+            </div>
+            <div className="flex items-center gap-3 rounded-xl border border-slate-800/60 bg-slate-900/40 p-3">
+              <input
+                type="color"
+                value={value}
+                onChange={(event) => updateTheme({ [key]: event.target.value })}
+                className="h-10 w-20 cursor-pointer rounded-md border border-slate-700 bg-slate-800"
+              />
+              <input
+                type="text"
+                value={value}
+                onChange={(event) => updateTheme({ [key]: event.target.value })}
+                className="flex-1 rounded-lg border border-slate-800/70 bg-slate-900/50 px-3 py-2 text-sm text-slate-200 focus:border-builder-accent focus:outline-none"
+              />
+            </div>
+          </label>
+        ))}
+      </div>
+
+      <div className="rounded-2xl border border-slate-800/60 bg-slate-900/40 p-6">
+        <h3 className="text-lg font-semibold">Current template</h3>
+        <p className="mt-1 text-sm text-slate-400">
+          You&apos;re working with <span className="font-medium text-slate-200">{selectedTemplate.name}</span>.
+        </p>
+        <div className="mt-4 grid grid-cols-2 gap-3 text-sm text-slate-300">
+          <div className="rounded-xl border border-slate-800/60 bg-slate-900/40 p-4">
+            <p className="text-xs uppercase tracking-wide text-slate-500">Style</p>
+            <p className="mt-1 font-medium">{selectedTemplate.category}</p>
+          </div>
+          <div className="rounded-xl border border-slate-800/60 bg-slate-900/40 p-4">
+            <p className="text-xs uppercase tracking-wide text-slate-500">Pages</p>
+            <p className="mt-1 font-medium">{selectedTemplate.pages.join(", ")}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,25 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  font-family: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+::-webkit-scrollbar {
+  width: 0.5rem;
+  height: 0.5rem;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.4);
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(56, 189, 248, 0.6);
+  border-radius: 9999px;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Prosite Builder",
+  description: "Craft professional websites with Prosite's builder."
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en" className="h-full bg-builder-background">
+      <body className="min-h-screen bg-builder-background text-slate-100 antialiased">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,32 @@
+import Link from "next/link";
+
+export default function HomePage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center gap-8 px-4 text-center">
+      <span className="rounded-full bg-builder-surface px-4 py-1 text-sm font-medium text-slate-300">
+        Prosite Builder
+      </span>
+      <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
+        Launch your next professional website in minutes.
+      </h1>
+      <p className="max-w-2xl text-lg text-slate-300">
+        Choose a premium template, customize every detail with our intuitive builder, and publish with a
+        subscription powered by Stripe.
+      </p>
+      <div className="flex flex-wrap items-center justify-center gap-4">
+        <Link
+          className="rounded-full bg-builder-accent px-6 py-3 text-base font-semibold text-slate-900 shadow-lg shadow-sky-500/30 transition hover:brightness-110"
+          href="/builder/theme"
+        >
+          Start Building
+        </Link>
+        <Link
+          className="rounded-full border border-slate-600 px-6 py-3 text-base font-semibold text-slate-200 transition hover:border-builder-accent hover:text-builder-accent"
+          href="#"
+        >
+          Explore Templates
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/success/page.tsx
+++ b/src/app/success/page.tsx
@@ -1,0 +1,11 @@
+export default function SuccessPage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center gap-6 px-4 text-center">
+      <h1 className="text-4xl font-semibold text-slate-100">You&apos;re all set!</h1>
+      <p className="text-slate-300">
+        Thanks for partnering with Prosite. Your project dashboard unlocks once onboarding is complete. Keep an eye on
+        your inbox for next steps.
+      </p>
+    </main>
+  );
+}

--- a/src/components/builder/DeviceControls.tsx
+++ b/src/components/builder/DeviceControls.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import clsx from "clsx";
+import { useBuilder } from "@/context/BuilderContext";
+
+const devices = [
+  { id: "desktop", label: "Desktop" },
+  { id: "tablet", label: "Tablet" },
+  { id: "mobile", label: "Mobile" }
+] as const;
+
+export function DeviceControls() {
+  const { device, setDevice } = useBuilder();
+
+  return (
+    <div className="flex items-center gap-2">
+      {devices.map((item) => (
+        <button
+          type="button"
+          key={item.id}
+          onClick={() => setDevice(item.id)}
+          className={clsx(
+            "rounded-full border px-4 py-1.5 text-sm font-medium transition",
+            device === item.id
+              ? "border-builder-accent bg-builder-accent/20 text-builder-accent"
+              : "border-slate-700/70 text-slate-400 hover:border-builder-accent/40 hover:text-slate-200"
+          )}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/builder/PageList.tsx
+++ b/src/components/builder/PageList.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+const defaultPages = ["Home", "About", "Services", "Contact"];
+
+type PageListProps = {
+  pages?: string[];
+};
+
+export function PageList({ pages = defaultPages }: PageListProps) {
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-semibold text-slate-300">Pages</p>
+        <button type="button" className="text-xs font-medium text-builder-accent transition hover:underline">
+          Manage
+        </button>
+      </div>
+      <div className="flex gap-2 overflow-x-auto pb-2">
+        {pages.map((page) => (
+          <button
+            type="button"
+            key={page}
+            className="whitespace-nowrap rounded-full border border-slate-700/70 bg-slate-900/40 px-3 py-1.5 text-xs font-medium text-slate-300 transition hover:border-builder-accent/40 hover:text-slate-100"
+          >
+            {page}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/builder/ProgressBar.tsx
+++ b/src/components/builder/ProgressBar.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import clsx from "clsx";
+
+type ProgressBarProps = {
+  steps: { label: string; href: string }[];
+  activeIndex: number;
+  onStepClick?: (href: string) => void;
+};
+
+export function ProgressBar({ steps, activeIndex, onStepClick }: ProgressBarProps) {
+  return (
+    <nav className="mx-auto flex w-full max-w-6xl items-center gap-4 px-6 pb-4">
+      {steps.map((step, index) => {
+        const isActive = index === activeIndex;
+        const isCompleted = activeIndex > index;
+
+        return (
+          <button
+            type="button"
+            key={step.href}
+            onClick={() => onStepClick?.(step.href)}
+            className="group flex flex-1 items-center gap-3 text-left"
+          >
+            <span
+              className={clsx(
+                "flex h-8 w-8 items-center justify-center rounded-full border-2 transition",
+                isCompleted && "border-builder-accent bg-builder-accent/20 text-builder-accent",
+                isActive && !isCompleted && "border-builder-accent bg-builder-accent/20 text-builder-accent",
+                !isActive && !isCompleted && "border-slate-700/80 text-slate-500 group-hover:border-builder-accent/40"
+              )}
+            >
+              {isCompleted ? (
+                <svg viewBox="0 0 20 20" fill="currentColor" className="h-4 w-4">
+                  <path
+                    fillRule="evenodd"
+                    d="M16.704 5.29a1 1 0 0 1 .006 1.414l-7.043 7.11a1 1 0 0 1-1.433.019L3.29 8.947a1 1 0 0 1 1.42-1.406l4.2 4.245 6.333-6.392a1 1 0 0 1 1.414-.006z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              ) : (
+                <span className="text-sm font-semibold">{index + 1}</span>
+              )}
+            </span>
+            <span className="flex flex-col">
+              <span
+                className={clsx(
+                  "text-sm font-semibold uppercase tracking-wide",
+                  isActive ? "text-slate-100" : "text-slate-500 group-hover:text-slate-300"
+                )}
+              >
+                {step.label}
+              </span>
+              <span className="text-xs text-slate-500">Step {index + 1}</span>
+            </span>
+            {index < steps.length - 1 ? (
+              <span className="hidden flex-1 border-t border-dashed border-slate-800/80 md:block" aria-hidden />
+            ) : null}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/builder/Sidebar.tsx
+++ b/src/components/builder/Sidebar.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import clsx from "clsx";
+import { useRouter } from "next/navigation";
+import { useBuilder } from "@/context/BuilderContext";
+import { PageList } from "./PageList";
+import { ThemeSelector } from "./ThemeSelector";
+
+type SidebarProps = {
+  steps: { label: string; href: string }[];
+  currentIndex: number;
+};
+
+export function Sidebar({ steps, currentIndex }: SidebarProps) {
+  const router = useRouter();
+  const { isSidebarCollapsed, toggleSidebar, selectedTemplate } = useBuilder();
+
+  const handleNavigate = (direction: "prev" | "next") => {
+    const nextIndex = direction === "prev" ? currentIndex - 1 : currentIndex + 1;
+    if (nextIndex >= 0 && nextIndex < steps.length) {
+      router.push(steps[nextIndex].href);
+    }
+  };
+
+  return (
+    <aside
+      className={clsx(
+        "relative flex h-full flex-col border-l border-slate-800/60 bg-builder-surface/80 transition-all duration-300",
+        isSidebarCollapsed ? "w-12" : "w-80"
+      )}
+    >
+      <button
+        type="button"
+        onClick={toggleSidebar}
+        className="absolute left-0 top-6 -translate-x-1/2 rounded-full border border-slate-800/70 bg-builder-surface p-1 text-slate-300 shadow-lg transition hover:border-builder-accent/60 hover:text-builder-accent"
+        aria-label={isSidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+      >
+        {isSidebarCollapsed ? "▶" : "◀"}
+      </button>
+
+      <div className={clsx("flex flex-1 flex-col gap-6 overflow-hidden px-6 py-6", isSidebarCollapsed && "hidden")}> 
+        <PageList pages={selectedTemplate.pages} />
+        <ThemeSelector />
+        <div className="mt-auto flex items-center justify-between gap-3">
+          <button
+            type="button"
+            onClick={() => handleNavigate("prev")}
+            disabled={currentIndex === 0}
+            className="flex-1 rounded-full border border-slate-700/70 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-builder-accent/40 hover:text-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={() => handleNavigate("next")}
+            disabled={currentIndex === steps.length - 1}
+            className="flex-1 rounded-full bg-builder-accent px-4 py-2 text-sm font-semibold text-slate-900 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Next
+          </button>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/builder/ThemeSelector.tsx
+++ b/src/components/builder/ThemeSelector.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import clsx from "clsx";
+import { useBuilder } from "@/context/BuilderContext";
+import { templates } from "@/lib/templates";
+
+const PAGE_SIZE = 3;
+
+export function ThemeSelector() {
+  const { selectedTemplate, selectTemplate } = useBuilder();
+  const [page, setPage] = useState(0);
+
+  const paginatedTemplates = useMemo(() => {
+    const start = page * PAGE_SIZE;
+    return templates.slice(start, start + PAGE_SIZE);
+  }, [page]);
+
+  const totalPages = Math.max(1, Math.ceil(templates.length / PAGE_SIZE));
+
+  useEffect(() => {
+    setPage((current) => Math.min(current, totalPages - 1));
+  }, [totalPages]);
+
+  const handlePrev = () => setPage((current) => Math.max(0, current - 1));
+  const handleNext = () => setPage((current) => Math.min(totalPages - 1, current + 1));
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-semibold text-slate-300">Template library</p>
+        <div className="flex items-center gap-2 text-slate-400">
+          <button
+            type="button"
+            onClick={handlePrev}
+            disabled={page === 0}
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-700/70 transition hover:border-builder-accent/40 hover:text-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            ◀
+          </button>
+          <button
+            type="button"
+            onClick={handleNext}
+            disabled={page >= totalPages - 1}
+            className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-700/70 transition hover:border-builder-accent/40 hover:text-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            ▶
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        {paginatedTemplates.map((template) => (
+          <button
+            type="button"
+            key={template.id}
+            onClick={() => selectTemplate(template.id)}
+            className={clsx(
+              "w-full rounded-2xl border p-4 text-left transition",
+              selectedTemplate.id === template.id
+                ? "border-builder-accent bg-builder-accent/10"
+                : "border-slate-800/70 bg-slate-900/40 hover:border-builder-accent/40"
+            )}
+          >
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold text-slate-100">{template.name}</p>
+                <p className="text-xs text-slate-400">{template.description}</p>
+              </div>
+              <div className="flex items-center gap-1.5">
+                {template.swatches.map((color) => (
+                  <span key={color} className="h-8 w-8 rounded-full border border-white/10" style={{ backgroundColor: color }} />
+                ))}
+              </div>
+            </div>
+          </button>
+        ))}
+      </div>
+
+      <p className="text-xs text-slate-500">More templates launching soon. Upgrade to unlock premium collections.</p>
+    </div>
+  );
+}

--- a/src/components/builder/WebsitePreview.tsx
+++ b/src/components/builder/WebsitePreview.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import clsx from "clsx";
+import { useBuilder } from "@/context/BuilderContext";
+import { renderTemplate } from "@/lib/renderTemplate";
+
+const deviceWidths: Record<"desktop" | "tablet" | "mobile", string> = {
+  desktop: "100%",
+  tablet: "768px",
+  mobile: "390px"
+};
+
+type TemplatePayload = {
+  html: string;
+  css: string;
+};
+
+export function WebsitePreview() {
+  const { device, selectedTemplate, theme, content } = useBuilder();
+  const [assets, setAssets] = useState<TemplatePayload | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+    const fetchTemplate = async () => {
+      setIsLoading(true);
+      setAssets(null);
+      try {
+        const response = await fetch(`/api/websites?templateId=${encodeURIComponent(selectedTemplate.id)}`);
+        if (!response.ok) {
+          throw new Error("Unable to load template");
+        }
+        const data = (await response.json()) as TemplatePayload;
+        if (isMounted) {
+          setAssets(data);
+        }
+      } catch (error) {
+        console.error(error);
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchTemplate();
+    return () => {
+      isMounted = false;
+    };
+  }, [selectedTemplate.id]);
+
+  const mergedData = useMemo(() => ({ ...theme, ...content }), [content, theme]);
+
+  const srcDoc = useMemo(() => {
+    if (!assets) {
+      return "";
+    }
+
+    const themedCss = `:root { --primary-color: ${theme.primaryColor}; --secondary-color: ${theme.secondaryColor}; --accent-color: ${theme.accentColor}; --background-color: ${theme.backgroundColor}; --text-color: ${theme.textColor}; } ${assets.css}`;
+
+    const html = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><style>${themedCss}</style></head><body>${renderTemplate(assets.html, mergedData)}</body></html>`;
+
+    return html;
+  }, [assets, mergedData, theme.accentColor, theme.backgroundColor, theme.primaryColor, theme.secondaryColor, theme.textColor]);
+
+  const handleFullPreview = () => {
+    if (!srcDoc) return;
+    const blob = new Blob([srcDoc], { type: "text/html" });
+    const url = URL.createObjectURL(blob);
+    const previewWindow = window.open(url, "_blank");
+    if (previewWindow) {
+      previewWindow.focus();
+    }
+    setTimeout(() => {
+      URL.revokeObjectURL(url);
+    }, 1000);
+  };
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center overflow-hidden bg-slate-950/40 px-6 py-8">
+      <div className="flex w-full max-w-5xl items-center justify-between pb-4 text-sm text-slate-400">
+        <p>
+          Previewing <span className="font-medium text-slate-200">{selectedTemplate.name}</span>
+        </p>
+        <button
+          type="button"
+          onClick={handleFullPreview}
+          disabled={!assets}
+          className="rounded-full border border-builder-accent/60 px-4 py-1.5 text-xs font-semibold text-builder-accent transition hover:bg-builder-accent/10 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Full Preview
+        </button>
+      </div>
+      <div className="flex h-full w-full flex-1 items-center justify-center overflow-hidden">
+        <div
+          className={clsx(
+            "relative flex h-full max-h-[640px] flex-1 items-center justify-center rounded-3xl border border-slate-800/60 bg-slate-900/60 shadow-xl shadow-black/40",
+            device === "mobile" && "py-8"
+          )}
+        >
+          {isLoading ? (
+            <div className="text-sm text-slate-400">Loading preview...</div>
+          ) : assets ? (
+            <iframe
+              key={`${selectedTemplate.id}-${device}`}
+              title="Website preview"
+              srcDoc={srcDoc}
+              style={{ width: deviceWidths[device], height: "100%" }}
+              className={clsx(
+                "h-full rounded-[22px] border border-slate-800/50 bg-white shadow-inner",
+                device === "desktop" && "mx-6",
+                device === "tablet" && "mx-6",
+                device === "mobile" && "mx-0 h-[640px] max-h-full w-[390px]"
+              )}
+            />
+          ) : (
+            <div className="max-w-sm text-center text-sm text-rose-400">
+              We couldn&apos;t load the template preview. Please refresh and try again.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/context/BuilderContext.tsx
+++ b/src/context/BuilderContext.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+import { templates, type TemplateDefinition } from "@/lib/templates";
+
+type Device = "desktop" | "tablet" | "mobile";
+
+type BuilderContextValue = {
+  device: Device;
+  setDevice: (device: Device) => void;
+  isSidebarCollapsed: boolean;
+  toggleSidebar: () => void;
+  selectedTemplate: TemplateDefinition;
+  selectTemplate: (templateId: string) => void;
+  theme: Record<string, string>;
+  updateTheme: (changes: Record<string, string>) => void;
+  content: Record<string, string>;
+  updateContent: (changes: Record<string, string>) => void;
+};
+
+const BuilderContext = createContext<BuilderContextValue | undefined>(undefined);
+
+const defaultTheme = {
+  primaryColor: "#38bdf8",
+  secondaryColor: "#0ea5e9",
+  accentColor: "#f472b6",
+  backgroundColor: "#020617",
+  textColor: "#e2e8f0"
+};
+
+const defaultContent = {
+  name: "Avery Johnson",
+  tagline: "Product Designer & Art Director",
+  about:
+    "I craft immersive digital experiences and lead cross-functional teams to deliver design systems that scale.",
+  resumeTitle: "Experience",
+  resumeSummary: "Previously at Pixelwave Studio, Dataloom, and Nova Labs.",
+  portfolioHeading: "Selected Work",
+  testimonialQuote: "Working with Avery elevated our brand presence tenfold.",
+  testimonialAuthor: "Jordan Smith, CEO at Nova Labs",
+  contactHeadline: "Let’s build something iconic.",
+  contactEmail: "hello@averyjohnson.design"
+};
+
+export function BuilderProvider({ children }: { children: React.ReactNode }) {
+  const [device, setDevice] = useState<Device>("desktop");
+  const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+  const [selectedTemplateId, setSelectedTemplateId] = useState<string>(templates[0]?.id ?? "");
+  const [theme, setTheme] = useState<Record<string, string>>(defaultTheme);
+  const [content, setContent] = useState<Record<string, string>>(defaultContent);
+
+  const selectedTemplate = useMemo(
+    () => templates.find((template) => template.id === selectedTemplateId) ?? templates[0],
+    [selectedTemplateId]
+  );
+
+  const toggleSidebar = useCallback(() => setIsSidebarCollapsed((prev) => !prev), []);
+
+  const updateTheme = useCallback((changes: Record<string, string>) => {
+    setTheme((prev) => ({ ...prev, ...changes }));
+  }, []);
+
+  const updateContent = useCallback((changes: Record<string, string>) => {
+    setContent((prev) => ({ ...prev, ...changes }));
+  }, []);
+
+  const selectTemplate = useCallback((templateId: string) => {
+    setSelectedTemplateId(templateId);
+  }, []);
+
+  const value = useMemo<BuilderContextValue>(
+    () => ({
+      device,
+      setDevice,
+      isSidebarCollapsed,
+      toggleSidebar,
+      selectedTemplate,
+      selectTemplate,
+      theme,
+      updateTheme,
+      content,
+      updateContent
+    }),
+    [content, device, isSidebarCollapsed, selectTemplate, selectedTemplate, theme, toggleSidebar]
+  );
+
+  return <BuilderContext.Provider value={value}>{children}</BuilderContext.Provider>;
+}
+
+export function useBuilder() {
+  const context = useContext(BuilderContext);
+  if (!context) {
+    throw new Error("useBuilder must be used within a BuilderProvider");
+  }
+  return context;
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,34 @@
+import mongoose from "mongoose";
+
+type MongooseGlobal = typeof globalThis & {
+  mongoose?: { conn: typeof mongoose | null; promise: Promise<typeof mongoose> | null };
+};
+
+const globalWithMongoose = globalThis as MongooseGlobal;
+
+if (!globalWithMongoose.mongoose) {
+  globalWithMongoose.mongoose = { conn: null, promise: null };
+}
+
+const cached = globalWithMongoose.mongoose;
+
+export async function connectToDatabase() {
+  const uri = process.env.MONGODB_URI;
+
+  if (!uri) {
+    throw new Error("MONGODB_URI environment variable is not set");
+  }
+
+  if (cached.conn) {
+    return cached.conn;
+  }
+
+  if (!cached.promise) {
+    cached.promise = mongoose.connect(uri, {
+      maxPoolSize: 5
+    });
+  }
+
+  cached.conn = await cached.promise;
+  return cached.conn;
+}

--- a/src/lib/renderTemplate.ts
+++ b/src/lib/renderTemplate.ts
@@ -1,0 +1,3 @@
+export function renderTemplate(html: string, data: Record<string, string>) {
+  return html.replace(/{{(.*?)}}/g, (_, key: string) => data[key.trim()] ?? "");
+}

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,0 +1,44 @@
+export type TemplateDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  pages: string[];
+  swatches: string[];
+  htmlFile: string;
+  cssFile: string;
+};
+
+export const templates: TemplateDefinition[] = [
+  {
+    id: "portfolio-creative",
+    name: "Portfolio Creative",
+    description: "Bold single-page portfolio ideal for designers and agencies.",
+    category: "Creative Portfolio",
+    pages: ["Home", "About", "Services", "Contact"],
+    swatches: ["#38bdf8", "#0ea5e9", "#f472b6"],
+    htmlFile: "index.html",
+    cssFile: "style.css"
+  }
+];
+
+export async function loadTemplateAssets(templateId: string) {
+  const template = templates.find((entry) => entry.id === templateId);
+  if (!template) {
+    throw new Error(`Template with id "${templateId}" not found`);
+  }
+
+  if (typeof window !== "undefined") {
+    throw new Error("loadTemplateAssets can only be used on the server");
+  }
+
+  const [fs, path] = await Promise.all([import("node:fs/promises"), import("node:path")]);
+  const basePath = path.join(process.cwd(), "templates", templateId);
+
+  const [html, css] = await Promise.all([
+    fs.readFile(path.join(basePath, template.htmlFile), "utf-8"),
+    fs.readFile(path.join(basePath, template.cssFile), "utf-8")
+  ]);
+
+  return { html, css };
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,24 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./src/app/**/*.{ts,tsx}",
+    "./src/components/**/*.{ts,tsx}",
+    "./src/lib/**/*.{ts,tsx}"
+  ],
+  theme: {
+    extend: {
+      colors: {
+        builder: {
+          background: "#0f172a",
+          surface: "#111c3a",
+          accent: "#38bdf8",
+          muted: "#1e293b"
+        }
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/templates/portfolio-creative/index.html
+++ b/templates/portfolio-creative/index.html
@@ -1,0 +1,107 @@
+<section class="layout">
+  <aside class="sidebar">
+    <div class="profile">
+      <div class="avatar">{{name}}</div>
+      <p class="tagline">{{tagline}}</p>
+    </div>
+    <nav class="nav">
+      <a href="#about">About</a>
+      <a href="#resume">Resume</a>
+      <a href="#portfolio">Portfolio</a>
+      <a href="#testimonials">Testimonials</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </aside>
+  <main class="content">
+    <section class="hero">
+      <p class="eyebrow">Now booking new collaborations</p>
+      <h1>{{name}}</h1>
+      <p class="lede">{{tagline}}</p>
+      <div class="actions">
+        <a class="button primary" href="#portfolio">View portfolio</a>
+        <a class="button secondary" href="#contact">Book a discovery call</a>
+      </div>
+    </section>
+
+    <section id="about" class="section about">
+      <h2>About</h2>
+      <p>{{about}}</p>
+    </section>
+
+    <section id="resume" class="section resume">
+      <h2>{{resumeTitle}}</h2>
+      <p>{{resumeSummary}}</p>
+      <ul class="timeline">
+        <li>
+          <span>2022 — Present</span>
+          <div>
+            <h3>Nova Labs</h3>
+            <p>Principal Product Designer guiding growth initiatives.</p>
+          </div>
+        </li>
+        <li>
+          <span>2020 — 2022</span>
+          <div>
+            <h3>Dataloom</h3>
+            <p>Built the design system powering the platform.</p>
+          </div>
+        </li>
+        <li>
+          <span>2017 — 2020</span>
+          <div>
+            <h3>Pixelwave Studio</h3>
+            <p>Led branding and experiential design for tech startups.</p>
+          </div>
+        </li>
+      </ul>
+    </section>
+
+    <section id="portfolio" class="section portfolio">
+      <div class="section-heading">
+        <h2>{{portfolioHeading}}</h2>
+        <a class="view-all" href="#">View all projects →</a>
+      </div>
+      <div class="grid">
+        <article>
+          <h3>Atlas SaaS Platform</h3>
+          <p>Product design & design system</p>
+        </article>
+        <article>
+          <h3>Flowwave Mobile</h3>
+          <p>UX strategy & brand identity</p>
+        </article>
+        <article>
+          <h3>Northstar Rebrand</h3>
+          <p>Visual direction & campaign</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="testimonials" class="section testimonials">
+      <h2>Testimonials</h2>
+      <blockquote>
+        <p>“{{testimonialQuote}}”</p>
+        <footer>— {{testimonialAuthor}}</footer>
+      </blockquote>
+    </section>
+
+    <section id="contact" class="section contact">
+      <h2>{{contactHeadline}}</h2>
+      <form class="contact-form">
+        <div class="field">
+          <label for="name">Name</label>
+          <input id="name" type="text" placeholder="Your name" />
+        </div>
+        <div class="field">
+          <label for="email">Email</label>
+          <input id="email" type="email" placeholder="you@example.com" value="{{contactEmail}}" />
+        </div>
+        <div class="field full">
+          <label for="message">Project details</label>
+          <textarea id="message" rows="3" placeholder="Tell me about your project"></textarea>
+        </div>
+        <button type="submit" class="button primary">Submit</button>
+      </form>
+    </section>
+  </main>
+</section>

--- a/templates/portfolio-creative/style.css
+++ b/templates/portfolio-creative/style.css
@@ -1,0 +1,295 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", sans-serif;
+  background: var(--background-color, #0f172a);
+  color: var(--text-color, #e2e8f0);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.layout {
+  display: grid;
+  min-height: 100vh;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+}
+
+.sidebar {
+  background: linear-gradient(180deg, rgba(2, 8, 23, 0.95), rgba(15, 23, 42, 0.9));
+  border-right: 1px solid rgba(148, 163, 184, 0.1);
+  padding: 3rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.profile .avatar {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--primary-color);
+}
+
+.profile .tagline {
+  margin-top: 0.5rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.nav a {
+  transition: color 150ms ease;
+}
+
+.nav a:hover {
+  color: var(--primary-color);
+}
+
+.content {
+  padding: 3.5rem 4rem;
+  background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.1), transparent 55%);
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin-bottom: 4rem;
+}
+
+.hero .eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.hero h1 {
+  font-size: clamp(2.8rem, 4vw, 4rem);
+  margin: 0;
+  color: var(--text-color);
+}
+
+.hero .lede {
+  font-size: 1.25rem;
+  max-width: 640px;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 200ms ease;
+}
+
+.button.primary {
+  background: var(--primary-color);
+  color: #0b1120;
+  box-shadow: 0 15px 35px rgba(56, 189, 248, 0.35);
+}
+
+.button.primary:hover {
+  filter: brightness(1.05);
+}
+
+.button.secondary {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: rgba(226, 232, 240, 0.9);
+}
+
+.button.secondary:hover {
+  border-color: var(--primary-color);
+  color: var(--primary-color);
+}
+
+.section {
+  margin-bottom: 4rem;
+}
+
+.section h2 {
+  font-size: 1.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.section p {
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.resume .timeline {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1.75rem;
+}
+
+.resume .timeline li {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.resume .timeline span {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.7);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.resume .timeline h3 {
+  margin: 0 0 0.25rem;
+  font-size: 1.1rem;
+}
+
+.portfolio .section-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.portfolio .view-all {
+  font-size: 0.9rem;
+  color: var(--accent-color);
+}
+
+.portfolio .grid {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.portfolio article {
+  padding: 1.75rem;
+  background: rgba(2, 6, 23, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.08);
+  border-radius: 1.5rem;
+  backdrop-filter: blur(10px);
+}
+
+.portfolio article h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: var(--text-color);
+}
+
+.portfolio article p {
+  margin-top: 0.5rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.testimonials blockquote {
+  margin: 0;
+  padding: 2.5rem;
+  background: rgba(15, 23, 42, 0.7);
+  border-left: 4px solid var(--accent-color);
+  border-radius: 1.5rem;
+  font-size: 1.1rem;
+  color: rgba(226, 232, 240, 0.9);
+  box-shadow: 0 20px 60px rgba(2, 6, 23, 0.4);
+}
+
+.testimonials footer {
+  margin-top: 1rem;
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.contact-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.contact-form .field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.contact-form .field.full {
+  grid-column: span 2;
+}
+
+.contact-form label {
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.contact-form input,
+.contact-form textarea {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 0.9rem;
+  padding: 0.85rem 1rem;
+  background: rgba(2, 6, 23, 0.5);
+  color: rgba(226, 232, 240, 0.9);
+  font-size: 0.95rem;
+}
+
+.contact-form textarea {
+  resize: vertical;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 2rem;
+  }
+
+  .nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+  }
+
+  .content {
+    padding: 3rem 2rem;
+  }
+
+  .resume .timeline {
+    gap: 1rem;
+  }
+
+  .resume .timeline li {
+    grid-template-columns: 1fr;
+  }
+
+  .contact-form {
+    grid-template-columns: 1fr;
+  }
+
+  .contact-form .field.full {
+    grid-column: span 1;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs", "**/*.mjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold the Next.js 15 + TypeScript + Tailwind workspace with global styling and routing
- implement builder context, UI components, and step pages with live template preview support
- add API placeholders, database utility, and the "portfolio-creative" template assets for extensible theming

## Testing
- not run (project scaffolding)


------
https://chatgpt.com/codex/tasks/task_e_68dc64c371908326832948810d29bb4c