### PR TITLE
Add server template helpers and API endpoint

### DIFF
--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+import { getTemplateCss, getTemplateHtml } from "@/lib/templates";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const templateId = params.id;
+
+  if (!templateId) {
+    return NextResponse.json({ error: "Template id is required" }, { status: 400 });
+  }
+
+  try {
+    const [html, css] = await Promise.all([
+      getTemplateHtml(templateId),
+      getTemplateCss(templateId)
+    ]);
+
+    return NextResponse.json({ html, css });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Unable to load template" }, { status: 404 });
+  }
+}

--- a/src/components/builder/ThemeSelector.tsx
+++ b/src/components/builder/ThemeSelector.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
 import { useBuilder } from "@/context/BuilderContext";
-import { templates } from "@/lib/templates";
+import { templates } from "@/lib/templateDefinitions";
 
 const PAGE_SIZE = 3;
 

--- a/src/components/builder/WebsitePreview.tsx
+++ b/src/components/builder/WebsitePreview.tsx
@@ -27,7 +27,7 @@ export function WebsitePreview() {
       setIsLoading(true);
       setAssets(null);
       try {
-        const response = await fetch(`/api/websites?templateId=${encodeURIComponent(selectedTemplate.id)}`);
+        const response = await fetch(`/api/templates/${encodeURIComponent(selectedTemplate.id)}`);
         if (!response.ok) {
           throw new Error("Unable to load template");
         }

--- a/src/context/BuilderContext.tsx
+++ b/src/context/BuilderContext.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useCallback, useContext, useMemo, useState } from "react";
-import { templates, type TemplateDefinition } from "@/lib/templates";
+import { templates, type TemplateDefinition } from "@/lib/templateDefinitions";
 
 type Device = "desktop" | "tablet" | "mobile";
 

--- a/src/lib/templateDefinitions.ts
+++ b/src/lib/templateDefinitions.ts
@@ -1,0 +1,23 @@
+export type TemplateDefinition = {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  pages: string[];
+  swatches: string[];
+  htmlFile: string;
+  cssFile: string;
+};
+
+export const templates: TemplateDefinition[] = [
+  {
+    id: "portfolio-creative",
+    name: "Portfolio Creative",
+    description: "Bold single-page portfolio ideal for designers and agencies.",
+    category: "Creative Portfolio",
+    pages: ["Home", "About", "Services", "Contact"],
+    swatches: ["#38bdf8", "#0ea5e9", "#f472b6"],
+    htmlFile: "index.html",
+    cssFile: "style.css"
+  }
+];

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -1,43 +1,83 @@
-export type TemplateDefinition = {
-  id: string;
-  name: string;
-  description: string;
-  category: string;
-  pages: string[];
-  swatches: string[];
-  htmlFile: string;
-  cssFile: string;
-};
+import fs from "fs/promises";
+import path from "path";
 
-export const templates: TemplateDefinition[] = [
-  {
-    id: "portfolio-creative",
-    name: "Portfolio Creative",
-    description: "Bold single-page portfolio ideal for designers and agencies.",
-    category: "Creative Portfolio",
-    pages: ["Home", "About", "Services", "Contact"],
-    swatches: ["#38bdf8", "#0ea5e9", "#f472b6"],
-    htmlFile: "index.html",
-    cssFile: "style.css"
+import { templates, type TemplateDefinition } from "./templateDefinitions";
+
+const templatesDir = path.join(process.cwd(), "templates");
+
+function sanitizeTemplateId(templateId: string) {
+  const normalized = path.normalize(templateId);
+  if (normalized.startsWith("..") || path.isAbsolute(normalized)) {
+    throw new Error("Invalid template identifier");
   }
-];
+  return normalized;
+}
 
-export async function loadTemplateAssets(templateId: string) {
-  const template = templates.find((entry) => entry.id === templateId);
-  if (!template) {
-    throw new Error(`Template with id "${templateId}" not found`);
+async function ensureDirectoryExists(dirPath: string) {
+  try {
+    const stat = await fs.stat(dirPath);
+    if (!stat.isDirectory()) {
+      throw new Error(`Expected directory at ${dirPath}`);
+    }
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`Template directory not found: ${dirPath}`);
+    }
+    throw error;
   }
+}
 
-  if (typeof window !== "undefined") {
-    throw new Error("loadTemplateAssets can only be used on the server");
+export function getTemplatesMetadata(): TemplateDefinition[] {
+  return templates;
+}
+
+export async function getTemplateList(): Promise<string[]> {
+  const entries = await fs.readdir(templatesDir, { withFileTypes: true });
+  return entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+}
+
+export async function getTemplateHtml(templateId: string): Promise<string> {
+  const safeId = sanitizeTemplateId(templateId);
+  const templatePath = path.join(templatesDir, safeId);
+  await ensureDirectoryExists(templatePath);
+
+  const templateMeta = templates.find((template) => template.id === safeId);
+  const htmlFileName = templateMeta?.htmlFile ?? "index.html";
+  const filePath = path.join(templatePath, htmlFileName);
+
+  try {
+    return await fs.readFile(filePath, "utf-8");
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`HTML file not found for template: ${templateId}`);
+    }
+    throw error;
   }
+}
 
-  const [fs, path] = await Promise.all([import("node:fs/promises"), import("node:path")]);
-  const basePath = path.join(process.cwd(), "templates", templateId);
+export async function getTemplateCss(templateId: string): Promise<string> {
+  const safeId = sanitizeTemplateId(templateId);
+  const templatePath = path.join(templatesDir, safeId);
+  await ensureDirectoryExists(templatePath);
 
+  const templateMeta = templates.find((template) => template.id === safeId);
+  const cssFileName = templateMeta?.cssFile ?? "style.css";
+  const filePath = path.join(templatePath, cssFileName);
+
+  try {
+    return await fs.readFile(filePath, "utf-8");
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(`CSS file not found for template: ${templateId}`);
+    }
+    throw error;
+  }
+}
+
+export async function loadTemplateAssets(templateId: string): Promise<{ html: string; css: string }> {
   const [html, css] = await Promise.all([
-    fs.readFile(path.join(basePath, template.htmlFile), "utf-8"),
-    fs.readFile(path.join(basePath, template.cssFile), "utf-8")
+    getTemplateHtml(templateId),
+    getTemplateCss(templateId)
   ]);
 
   return { html, css };


### PR DESCRIPTION
## Summary
- replace node:fs/promises usage with fs/promises and add server-side helpers for reading template assets
- move template metadata into a client-safe module and update builder UI imports
- add an /api/templates/[id] endpoint that serves template HTML and CSS via the new helpers

## Testing
- npm run lint *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7101cafc83269ff2420499d5bb26