### PR TITLE
feat: enhance builder preview controls and template endpoint

### DIFF
--- a/src/app/api/templates/[templateId]/route.ts
+++ b/src/app/api/templates/[templateId]/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { loadTemplateAssets } from "@/lib/templates";
+
+type RouteContext = {
+  params: {
+    templateId: string;
+  };
+};
+
+export async function GET(_request: Request, context: RouteContext) {
+  const templateId = context.params?.templateId;
+
+  if (!templateId) {
+    return NextResponse.json({ error: "Template identifier is required" }, { status: 400 });
+  }
+
+  try {
+    const assets = await loadTemplateAssets(templateId);
+    return NextResponse.json(assets);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json({ error: "Template not found" }, { status: 404 });
+  }
+}

--- a/src/components/builder/DeviceControls.tsx
+++ b/src/components/builder/DeviceControls.tsx
@@ -10,25 +10,51 @@ const devices = [
 ] as const;
 
 export function DeviceControls() {
-  const { device, setDevice } = useBuilder();
+  const { device, setDevice, previewDocument } = useBuilder();
+
+  const handleFullPreview = () => {
+    if (!previewDocument) return;
+
+    const blob = new Blob([previewDocument], { type: "text/html" });
+    const url = URL.createObjectURL(blob);
+    const previewWindow = window.open(url, "_blank");
+
+    if (previewWindow) {
+      previewWindow.focus();
+    }
+
+    setTimeout(() => {
+      URL.revokeObjectURL(url);
+    }, 1000);
+  };
 
   return (
-    <div className="flex items-center gap-2">
-      {devices.map((item) => (
-        <button
-          type="button"
-          key={item.id}
-          onClick={() => setDevice(item.id)}
-          className={clsx(
-            "rounded-full border px-4 py-1.5 text-sm font-medium transition",
-            device === item.id
-              ? "border-builder-accent bg-builder-accent/20 text-builder-accent"
-              : "border-slate-700/70 text-slate-400 hover:border-builder-accent/40 hover:text-slate-200"
-          )}
-        >
-          {item.label}
-        </button>
-      ))}
+    <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2 rounded-full border border-slate-800/70 bg-slate-900/40 p-1">
+        {devices.map((item) => (
+          <button
+            type="button"
+            key={item.id}
+            onClick={() => setDevice(item.id)}
+            className={clsx(
+              "rounded-full px-4 py-1.5 text-sm font-medium transition",
+              device === item.id
+                ? "bg-builder-accent text-slate-950 shadow"
+                : "text-slate-400 hover:bg-slate-800/80 hover:text-slate-100"
+            )}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={handleFullPreview}
+        disabled={!previewDocument}
+        className="rounded-full border border-builder-accent/60 px-5 py-1.5 text-sm font-semibold text-builder-accent transition hover:bg-builder-accent/10 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Full Preview
+      </button>
     </div>
   );
 }

--- a/src/components/builder/WebsitePreview.tsx
+++ b/src/components/builder/WebsitePreview.tsx
@@ -17,7 +17,7 @@ type TemplatePayload = {
 };
 
 export function WebsitePreview() {
-  const { device, selectedTemplate, theme, content } = useBuilder();
+  const { device, selectedTemplate, theme, content, setPreviewDocument } = useBuilder();
   const [assets, setAssets] = useState<TemplatePayload | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -26,6 +26,7 @@ export function WebsitePreview() {
     const fetchTemplate = async () => {
       setIsLoading(true);
       setAssets(null);
+      setPreviewDocument("");
       try {
         const response = await fetch(`/api/templates/${encodeURIComponent(selectedTemplate.id)}`);
         if (!response.ok) {
@@ -48,7 +49,7 @@ export function WebsitePreview() {
     return () => {
       isMounted = false;
     };
-  }, [selectedTemplate.id]);
+  }, [selectedTemplate.id, setPreviewDocument]);
 
   const mergedData = useMemo(() => ({ ...theme, ...content }), [content, theme]);
 
@@ -64,18 +65,13 @@ export function WebsitePreview() {
     return html;
   }, [assets, mergedData, theme.accentColor, theme.backgroundColor, theme.primaryColor, theme.secondaryColor, theme.textColor]);
 
-  const handleFullPreview = () => {
-    if (!srcDoc) return;
-    const blob = new Blob([srcDoc], { type: "text/html" });
-    const url = URL.createObjectURL(blob);
-    const previewWindow = window.open(url, "_blank");
-    if (previewWindow) {
-      previewWindow.focus();
-    }
-    setTimeout(() => {
-      URL.revokeObjectURL(url);
-    }, 1000);
-  };
+  useEffect(() => {
+    setPreviewDocument(srcDoc);
+  }, [setPreviewDocument, srcDoc]);
+
+  useEffect(() => () => {
+    setPreviewDocument("");
+  }, [setPreviewDocument]);
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center overflow-hidden bg-slate-950/40 px-6 py-8">
@@ -83,14 +79,6 @@ export function WebsitePreview() {
         <p>
           Previewing <span className="font-medium text-slate-200">{selectedTemplate.name}</span>
         </p>
-        <button
-          type="button"
-          onClick={handleFullPreview}
-          disabled={!assets}
-          className="rounded-full border border-builder-accent/60 px-4 py-1.5 text-xs font-semibold text-builder-accent transition hover:bg-builder-accent/10 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Full Preview
-        </button>
       </div>
       <div className="flex h-full w-full flex-1 items-center justify-center overflow-hidden">
         <div

--- a/src/context/BuilderContext.tsx
+++ b/src/context/BuilderContext.tsx
@@ -16,6 +16,8 @@ type BuilderContextValue = {
   updateTheme: (changes: Record<string, string>) => void;
   content: Record<string, string>;
   updateContent: (changes: Record<string, string>) => void;
+  previewDocument: string;
+  setPreviewDocument: (doc: string) => void;
 };
 
 const BuilderContext = createContext<BuilderContextValue | undefined>(undefined);
@@ -48,6 +50,7 @@ export function BuilderProvider({ children }: { children: React.ReactNode }) {
   const [selectedTemplateId, setSelectedTemplateId] = useState<string>(templates[0]?.id ?? "");
   const [theme, setTheme] = useState<Record<string, string>>(defaultTheme);
   const [content, setContent] = useState<Record<string, string>>(defaultContent);
+  const [previewDocument, setPreviewDocument] = useState<string>("");
 
   const selectedTemplate = useMemo(
     () => templates.find((template) => template.id === selectedTemplateId) ?? templates[0],
@@ -79,9 +82,24 @@ export function BuilderProvider({ children }: { children: React.ReactNode }) {
       theme,
       updateTheme,
       content,
-      updateContent
+      updateContent,
+      previewDocument,
+      setPreviewDocument
     }),
-    [content, device, isSidebarCollapsed, selectTemplate, selectedTemplate, theme, toggleSidebar]
+    [
+      content,
+      device,
+      isSidebarCollapsed,
+      previewDocument,
+      selectTemplate,
+      selectedTemplate,
+      setDevice,
+      setPreviewDocument,
+      theme,
+      toggleSidebar,
+      updateContent,
+      updateTheme
+    ]
   );
 
   return <BuilderContext.Provider value={value}>{children}</BuilderContext.Provider>;


### PR DESCRIPTION
## Summary
- expose rendered template HTML in context so device controls can launch the full preview
- restyle device picker with a dedicated full preview button and move iframe launch logic there
- add a template assets API endpoint and wire the preview iframe to keep context in sync

## Testing
- npm run lint *(fails: next binary unavailable in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc769e87f48326ad72f4643d415dd8