### PR TITLE
Enhance builder preview experience

### DIFF
--- a/src/components/builder/DeviceControls.tsx
+++ b/src/components/builder/DeviceControls.tsx
@@ -10,25 +10,36 @@ const devices = [
 ] as const;
 
 export function DeviceControls() {
-  const { device, setDevice } = useBuilder();
+  const { device, setDevice, openPreview, isPreviewReady } = useBuilder();
 
   return (
-    <div className="flex items-center gap-2">
-      {devices.map((item) => (
-        <button
-          type="button"
-          key={item.id}
-          onClick={() => setDevice(item.id)}
-          className={clsx(
-            "rounded-full border px-4 py-1.5 text-sm font-medium transition",
-            device === item.id
-              ? "border-builder-accent bg-builder-accent/20 text-builder-accent"
-              : "border-slate-700/70 text-slate-400 hover:border-builder-accent/40 hover:text-slate-200"
-          )}
-        >
-          {item.label}
-        </button>
-      ))}
+    <div className="flex items-center gap-3">
+      <div className="flex items-center gap-2">
+        {devices.map((item) => (
+          <button
+            type="button"
+            key={item.id}
+            onClick={() => setDevice(item.id)}
+            className={clsx(
+              "rounded-full border px-4 py-1.5 text-sm font-medium transition",
+              device === item.id
+                ? "border-builder-accent bg-builder-accent/20 text-builder-accent"
+                : "border-slate-700/70 text-slate-400 hover:border-builder-accent/40 hover:text-slate-200"
+            )}
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+      <span className="hidden h-5 w-px bg-slate-800/60 sm:block" aria-hidden />
+      <button
+        type="button"
+        onClick={openPreview}
+        disabled={!isPreviewReady}
+        className="rounded-full border border-builder-accent/60 px-4 py-1.5 text-xs font-semibold text-builder-accent transition hover:bg-builder-accent/10 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Full Preview
+      </button>
     </div>
   );
 }

--- a/src/components/builder/WebsitePreview.tsx
+++ b/src/components/builder/WebsitePreview.tsx
@@ -17,7 +17,7 @@ type TemplatePayload = {
 };
 
 export function WebsitePreview() {
-  const { device, selectedTemplate, theme, content } = useBuilder();
+  const { device, selectedTemplate, theme, content, updatePreviewDocument } = useBuilder();
   const [assets, setAssets] = useState<TemplatePayload | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -64,33 +64,16 @@ export function WebsitePreview() {
     return html;
   }, [assets, mergedData, theme.accentColor, theme.backgroundColor, theme.primaryColor, theme.secondaryColor, theme.textColor]);
 
-  const handleFullPreview = () => {
-    if (!srcDoc) return;
-    const blob = new Blob([srcDoc], { type: "text/html" });
-    const url = URL.createObjectURL(blob);
-    const previewWindow = window.open(url, "_blank");
-    if (previewWindow) {
-      previewWindow.focus();
-    }
-    setTimeout(() => {
-      URL.revokeObjectURL(url);
-    }, 1000);
-  };
+  useEffect(() => {
+    updatePreviewDocument(srcDoc);
+  }, [srcDoc, updatePreviewDocument]);
 
   return (
     <div className="flex flex-1 flex-col items-center justify-center overflow-hidden bg-slate-950/40 px-6 py-8">
-      <div className="flex w-full max-w-5xl items-center justify-between pb-4 text-sm text-slate-400">
+      <div className="flex w-full max-w-6xl items-center justify-start pb-4 text-sm text-slate-400">
         <p>
           Previewing <span className="font-medium text-slate-200">{selectedTemplate.name}</span>
         </p>
-        <button
-          type="button"
-          onClick={handleFullPreview}
-          disabled={!assets}
-          className="rounded-full border border-builder-accent/60 px-4 py-1.5 text-xs font-semibold text-builder-accent transition hover:bg-builder-accent/10 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          Full Preview
-        </button>
       </div>
       <div className="flex h-full w-full flex-1 items-center justify-center overflow-hidden">
         <div


### PR DESCRIPTION
## Summary
- store rendered template HTML in the builder context and expose helpers for preview availability
- update device controls with a full preview action while keeping the sidebar-responsive layout intact
- sync the website preview iframe with the shared state and expand its header area for improved focus

## Testing
- Unable to run `npm run lint` (npm registry returned 403 during dependency install)


------
https://chatgpt.com/codex/tasks/task_e_68dc7abdd04c8326b141631e349b7461