### PR TITLE
Adjust builder layout to improve preview area

### DIFF
--- a/src/app/builder/BuilderRoot.tsx
+++ b/src/app/builder/BuilderRoot.tsx
@@ -43,14 +43,14 @@ export default function BuilderRoot({ children }: BuilderRootProps) {
           </div>
           <ProgressBar steps={steps} activeIndex={currentStep} onStepClick={(href) => router.push(href)} />
         </header>
-        <main className="flex flex-1 overflow-hidden">
-          <section className="flex flex-1 flex-col overflow-hidden">
+        <main className="flex flex-1 min-h-0">
+          <section className="flex flex-1 flex-col min-h-0">
             <div className="flex items-center justify-end border-b border-slate-800/60 bg-builder-surface px-6 py-3">
               <DeviceControls />
             </div>
-            <div className="flex flex-1 overflow-hidden">
-              <div className="flex flex-1 flex-col h-full overflow-hidden">
-                <div className="flex flex-1 overflow-hidden">
+            <div className="flex flex-1 min-h-0">
+              <div className="flex flex-1 flex-col min-h-0">
+                <div className="flex flex-1 min-h-0">
                   <WebsitePreview />
                 </div>
                 <div className="border-t border-slate-800/60 bg-builder-surface/60 backdrop-blur">

--- a/src/components/builder/WebsitePreview.tsx
+++ b/src/components/builder/WebsitePreview.tsx
@@ -69,7 +69,7 @@ export function WebsitePreview() {
   }, [srcDoc, updatePreviewDocument]);
 
   return (
-    <div className="flex flex-1 flex-col items-center justify-center overflow-hidden bg-slate-950/40 px-6 py-8">
+    <div className="flex h-full min-h-0 flex-1 flex-col items-center justify-center overflow-hidden bg-slate-950/40 px-6 py-8">
       <div className="flex w-full max-w-6xl items-center justify-start pb-4 text-sm text-slate-400">
         <p>
           Previewing <span className="font-medium text-slate-200">{selectedTemplate.name}</span>
@@ -78,7 +78,7 @@ export function WebsitePreview() {
       <div className="flex h-full w-full flex-1 items-center justify-center overflow-hidden">
         <div
           className={clsx(
-            "relative flex h-full max-h-[90vh] flex-1 items-center justify-center rounded-3xl border border-slate-800/60 bg-slate-900/60 shadow-xl shadow-black/40 transition-all",
+            "relative flex h-full max-h-[90vh] min-h-[36rem] flex-1 items-center justify-center rounded-3xl border border-slate-800/60 bg-slate-900/60 shadow-xl shadow-black/40 transition-all md:min-h-[40rem] lg:min-h-[48rem]",
             device === "mobile" && "py-8"
           )}
         >


### PR DESCRIPTION
## Summary
- replace overflow clipping on the builder layout with min-h-0 constraints so the preview column can expand and scroll
- give the preview container responsive minimum heights so desktop and tablet frames stay tall

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc92a4b0e88326809553c1e8d56c95