### PR TITLE
Increase builder preview height in builder preview

### DIFF
--- a/src/components/builder/WebsitePreview.tsx
+++ b/src/components/builder/WebsitePreview.tsx
@@ -78,7 +78,7 @@ export function WebsitePreview() {
       <div className="flex h-full w-full flex-1 items-start justify-center overflow-hidden">
         <div
           className={clsx(
-            "relative flex w-full max-h-[70vh] min-h-[28rem] items-center justify-center overflow-y-auto rounded-3xl border border-slate-800/60 bg-slate-900/60 shadow-xl shadow-black/40 transition-all md:max-h-[75vh] md:min-h-[40rem] lg:max-h-[80vh] lg:min-h-[48rem]",
+            "relative flex w-full max-h-[140vh] min-h-[56rem] items-center justify-center overflow-y-auto rounded-3xl border border-slate-800/60 bg-slate-900/60 shadow-xl shadow-black/40 transition-all md:max-h-[150vh] md:min-h-[80rem] lg:max-h-[160vh] lg:min-h-[96rem]",
             device === "mobile" && "py-8"
           )}
         >


### PR DESCRIPTION
## Summary
- double the website preview container height constraints while retaining scroll behavior for overflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc97e798b88326a1a65b9daf73673d