### PR TITLE
Fix builder preview sizing and layout

### DIFF
--- a/src/app/builder/BuilderRoot.tsx
+++ b/src/app/builder/BuilderRoot.tsx
@@ -49,12 +49,12 @@ export default function BuilderRoot({ children }: BuilderRootProps) {
               <DeviceControls />
             </div>
             <div className="flex flex-1 min-h-0">
-              <div className="flex flex-1 flex-col min-h-0">
-                <div className="flex flex-1 min-h-0">
+              <div className="flex flex-col h-full flex-1 min-h-0">
+                <div className="flex-1 min-h-0">
                   <WebsitePreview />
                 </div>
                 <div className="border-t border-slate-800/60 bg-builder-surface/60 backdrop-blur">
-                  <div className="mx-auto w-full max-w-5xl max-h-[22rem] shrink-0 overflow-y-auto px-6 py-6">
+                  <div className="mx-auto w-full max-w-5xl max-h-[26rem] shrink-0 overflow-y-auto px-6 py-6">
                     {children}
                   </div>
                 </div>

--- a/src/components/builder/WebsitePreview.tsx
+++ b/src/components/builder/WebsitePreview.tsx
@@ -78,25 +78,29 @@ export function WebsitePreview() {
       <div className="flex h-full w-full flex-1 items-start justify-center overflow-hidden">
         <div
           className={clsx(
-            "relative flex w-full max-h-[140vh] min-h-[56rem] items-center justify-center overflow-y-auto rounded-3xl border border-slate-800/60 bg-slate-900/60 shadow-xl shadow-black/40 transition-all md:max-h-[150vh] md:min-h-[80rem] lg:max-h-[160vh] lg:min-h-[96rem]",
+            "relative flex h-full w-full flex-1 items-center justify-center overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/60 shadow-xl shadow-black/40 transition-all",
             device === "mobile" && "py-8"
           )}
         >
           {isLoading ? (
             <div className="text-sm text-slate-400">Loading preview...</div>
           ) : assets ? (
-            <iframe
-              key={`${selectedTemplate.id}-${device}`}
-              title="Website preview"
-              srcDoc={srcDoc}
-              style={{ width: deviceWidths[device] }}
+            <div
               className={clsx(
-                "w-full rounded-[22px] border border-slate-800/50 bg-white shadow-inner transition-all",
-                device === "desktop" && "mx-6",
-                device === "tablet" && "mx-6",
-                device === "mobile" && "mx-0"
+                "flex h-full w-full items-center justify-center",
+                device === "desktop" && "px-6",
+                device === "tablet" && "px-6",
+                device === "mobile" && "px-0"
               )}
-            />
+              style={{ maxWidth: deviceWidths[device] }}
+            >
+              <iframe
+                key={`${selectedTemplate.id}-${device}`}
+                title="Website preview"
+                srcDoc={srcDoc}
+                className="h-full w-full rounded-[22px] border border-slate-800/50 bg-white shadow-inner transition-all"
+              />
+            </div>
           ) : (
             <div className="max-w-sm text-center text-sm text-rose-400">
               We couldn&apos;t load the template preview. Please refresh and try again.


### PR DESCRIPTION
## Summary
- allow the builder layout to flex vertically so the preview area can expand while keeping the form panel constrained
- update the preview wrapper to use flex sizing and ensure the iframe fills the available space without hard-coded heights

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd4010fcc08326ba58aa6f5f9a87a4