### PR TITLE
Improve builder preview zoom and guided content editor

### DIFF
--- a/src/components/builder/Sidebar.tsx
+++ b/src/components/builder/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import clsx from "clsx";
 import { useRouter } from "next/navigation";
 import { useBuilder } from "@/context/BuilderContext";
@@ -31,6 +31,61 @@ type ContentFieldKey =
   | "testimonialAuthor"
   | "contactHeadline";
 
+type ContentSection = {
+  id: string;
+  title: string;
+  fields: {
+    key: ContentFieldKey;
+    label: string;
+    type?: "textarea" | "email" | "text";
+  }[];
+};
+
+const contentSections: ContentSection[] = [
+  {
+    id: "home",
+    title: "Hero Section",
+    fields: [
+      { key: "name", label: "Hero headline" },
+      { key: "tagline", label: "Hero tagline" },
+    ],
+  },
+  {
+    id: "about",
+    title: "About Section",
+    fields: [{ key: "about", label: "About section", type: "textarea" }],
+  },
+  {
+    id: "services",
+    title: "Experience Section",
+    fields: [
+      { key: "resumeTitle", label: "Resume section title" },
+      { key: "resumeSummary", label: "Resume summary", type: "textarea" },
+    ],
+  },
+  {
+    id: "portfolio",
+    title: "Portfolio Section",
+    fields: [{ key: "portfolioHeading", label: "Portfolio heading" }],
+  },
+  {
+    id: "testimonials",
+    title: "Testimonials Section",
+    fields: [
+      { key: "testimonialQuote", label: "Testimonial quote", type: "textarea" },
+      { key: "testimonialAuthor", label: "Testimonial author" },
+    ],
+  },
+  {
+    id: "contact",
+    title: "Contact Section",
+    fields: [
+      { key: "contactHeadline", label: "Contact headline" },
+      { key: "contactEmail", label: "Contact email", type: "email" },
+    ],
+  },
+];
+
 export function Sidebar({ steps, currentIndex }: SidebarProps) {
   const router = useRouter();
   const {
@@ -39,6 +94,7 @@ export function Sidebar({ steps, currentIndex }: SidebarProps) {
     selectedTemplate,
     content,
     updateContent,
+    previewFrame,
   } = useBuilder();
   const [activeTab, setActiveTab] = useState<TabId>("pages");
 
@@ -110,7 +166,11 @@ export function Sidebar({ steps, currentIndex }: SidebarProps) {
                 {activeTab === "theme" ? <ThemeSelector /> : null}
 
                 {activeTab === "content" ? (
-                  <ContentEditor content={content} updateContent={updateContent} />
+                  <ContentEditor
+                    content={content}
+                    updateContent={updateContent}
+                    previewFrame={previewFrame}
+                  />
                 ) : null}
               </div>
             </div>
@@ -145,49 +205,95 @@ export function Sidebar({ steps, currentIndex }: SidebarProps) {
 type ContentEditorProps = {
   content: Record<string, string>;
   updateContent: (changes: Record<string, string>) => void;
+  previewFrame: HTMLIFrameElement | null;
 };
 
-function ContentEditor({ content, updateContent }: ContentEditorProps) {
-  const fields: {
-    key: ContentFieldKey;
-    label: string;
-    helper?: string;
-    type?: "textarea" | "email" | "text";
-  }[] = [
-    { key: "name", label: "Hero headline" },
-    { key: "tagline", label: "Hero tagline" },
-    { key: "about", label: "About section", type: "textarea" },
-    { key: "portfolioHeading", label: "Portfolio heading" },
-    { key: "testimonialQuote", label: "Testimonial quote", type: "textarea" },
-    { key: "testimonialAuthor", label: "Testimonial author" },
-    { key: "resumeTitle", label: "Resume section title" },
-    { key: "resumeSummary", label: "Resume summary", type: "textarea" },
-    { key: "contactHeadline", label: "Contact headline" },
-    { key: "contactEmail", label: "Contact email", type: "email" },
-  ];
+function ContentEditor({ content, updateContent, previewFrame }: ContentEditorProps) {
+  const [currentSectionIndex, setCurrentSectionIndex] = useState(0);
+
+  const currentSection = contentSections[currentSectionIndex];
+
+  useEffect(() => {
+    if (!previewFrame?.contentWindow || !currentSection) {
+      return;
+    }
+
+    previewFrame.contentWindow.postMessage(
+      {
+        type: "scroll-to",
+        id: currentSection.id,
+      },
+      "*"
+    );
+  }, [currentSection, previewFrame]);
+
+  if (!currentSection) {
+    return null;
+  }
+
+  const isFirst = currentSectionIndex === 0;
+  const isLast = currentSectionIndex === contentSections.length - 1;
+
+  const handleNavigate = (direction: "prev" | "next") => {
+    setCurrentSectionIndex((prevIndex) => {
+      if (direction === "prev") {
+        return prevIndex > 0 ? prevIndex - 1 : prevIndex;
+      }
+      if (direction === "next") {
+        return prevIndex < contentSections.length - 1 ? prevIndex + 1 : prevIndex;
+      }
+      return prevIndex;
+    });
+  };
 
   return (
-    <form className="space-y-4" onSubmit={(event) => event.preventDefault()}>
-      {fields.map((field) => (
-        <label key={field.key} className="flex flex-col gap-2">
-          <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">{field.label}</span>
-          {field.type === "textarea" ? (
-            <textarea
-              value={content[field.key] ?? ""}
-              onChange={(event) => updateContent({ [field.key]: event.target.value })}
-              rows={4}
-              className="w-full rounded-xl border border-gray-800 bg-gray-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner shadow-black/40 transition focus:border-builder-accent focus:outline-none"
-            />
-          ) : (
-            <input
-              type={field.type ?? "text"}
-              value={content[field.key] ?? ""}
-              onChange={(event) => updateContent({ [field.key]: event.target.value })}
-              className="w-full rounded-xl border border-gray-800 bg-gray-950/60 px-3 py-2 text-sm text-slate-100 transition focus:border-builder-accent focus:outline-none"
-            />
-          )}
-        </label>
-      ))}
-    </form>
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-semibold text-slate-100">
+          Editing: <span className="text-slate-300">{currentSection.title}</span>
+        </p>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => handleNavigate("prev")}
+            disabled={isFirst}
+            className="rounded-full border border-gray-800 bg-gray-950/70 px-3 py-1.5 text-xs font-semibold text-slate-300 transition hover:border-builder-accent/60 hover:text-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            ← Previous
+          </button>
+          <button
+            type="button"
+            onClick={() => handleNavigate("next")}
+            disabled={isLast}
+            className="rounded-full border border-gray-800 bg-gray-950/70 px-3 py-1.5 text-xs font-semibold text-slate-300 transition hover:border-builder-accent/60 hover:text-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Next →
+          </button>
+        </div>
+      </div>
+
+      <form className="space-y-4 rounded-2xl border border-gray-800/60 bg-gray-950/50 p-4" onSubmit={(event) => event.preventDefault()}>
+        {currentSection.fields.map((field) => (
+          <label key={field.key} className="flex flex-col gap-2">
+            <span className="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">{field.label}</span>
+            {field.type === "textarea" ? (
+              <textarea
+                value={content[field.key] ?? ""}
+                onChange={(event) => updateContent({ [field.key]: event.target.value })}
+                rows={4}
+                className="w-full rounded-xl border border-gray-800 bg-gray-950/60 px-3 py-2 text-sm text-slate-100 shadow-inner shadow-black/40 transition focus:border-builder-accent focus:outline-none"
+              />
+            ) : (
+              <input
+                type={field.type ?? "text"}
+                value={content[field.key] ?? ""}
+                onChange={(event) => updateContent({ [field.key]: event.target.value })}
+                className="w-full rounded-xl border border-gray-800 bg-gray-950/60 px-3 py-2 text-sm text-slate-100 transition focus:border-builder-accent focus:outline-none"
+              />
+            )}
+          </label>
+        ))}
+      </form>
+    </div>
   );
 }

--- a/src/components/builder/WebsitePreview.tsx
+++ b/src/components/builder/WebsitePreview.tsx
@@ -38,8 +38,8 @@ export function WebsitePreview() {
   } = useBuilder();
   const [assets, setAssets] = useState<TemplatePayload | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [zoom, setZoom] = useState(1);
-  const [isAutoFit, setIsAutoFit] = useState(true);
+  const [zoom, setZoom] = useState(0.6);
+  const [isAutoFit, setIsAutoFit] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const setIframeRef = useCallback(


### PR DESCRIPTION
## Summary
- set the builder preview to open at 60% zoom instead of fitting automatically
- show a single content section form at a time with navigation controls and section titles
- scroll the live preview to the selected section when switching forms for easier editing

## Testing
- npm run lint *(fails: next-env triple slash reference rule)*

------
https://chatgpt.com/codex/tasks/task_e_68dd6e3b2d8c8326aa9c68006e827f02