### PR TITLE
Display templates on homepage

### DIFF
--- a/public/placeholder-template.svg
+++ b/public/placeholder-template.svg
@@ -1,0 +1,16 @@
+<svg width="640" height="480" viewBox="0 0 640 480" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="480" rx="32" fill="url(#gradient)"/>
+  <rect x="64" y="72" width="512" height="72" rx="12" fill="white" fill-opacity="0.08"/>
+  <rect x="64" y="168" width="320" height="24" rx="12" fill="white" fill-opacity="0.16"/>
+  <rect x="64" y="216" width="224" height="24" rx="12" fill="white" fill-opacity="0.08"/>
+  <rect x="64" y="280" width="512" height="140" rx="18" fill="white" fill-opacity="0.08"/>
+  <path d="M160 308H416" stroke="white" stroke-opacity="0.3" stroke-width="3" stroke-linecap="round"/>
+  <path d="M160 344H448" stroke="white" stroke-opacity="0.2" stroke-width="3" stroke-linecap="round"/>
+  <path d="M160 380H384" stroke="white" stroke-opacity="0.2" stroke-width="3" stroke-linecap="round"/>
+  <defs>
+    <linearGradient id="gradient" x1="40" y1="40" x2="600" y2="440" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#0EA5E9"/>
+      <stop offset="1" stop-color="#1E1B4B"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/public/thumbnails/portfolio-creative.svg
+++ b/public/thumbnails/portfolio-creative.svg
@@ -1,0 +1,20 @@
+<svg width="640" height="480" viewBox="0 0 640 480" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="640" height="480" rx="32" fill="#0F172A"/>
+  <rect x="64" y="64" width="184" height="184" rx="24" fill="#1E293B"/>
+  <rect x="64" y="272" width="184" height="16" rx="8" fill="#38BDF8"/>
+  <rect x="272" y="72" width="304" height="48" rx="16" fill="#1E293B"/>
+  <rect x="272" y="136" width="304" height="16" rx="8" fill="#CBD5F5" fill-opacity="0.55"/>
+  <rect x="272" y="168" width="304" height="16" rx="8" fill="#CBD5F5" fill-opacity="0.35"/>
+  <rect x="272" y="200" width="240" height="16" rx="8" fill="#CBD5F5" fill-opacity="0.2"/>
+  <rect x="272" y="248" width="304" height="72" rx="18" fill="#1E293B"/>
+  <rect x="272" y="336" width="304" height="72" rx="18" fill="#1E293B"/>
+  <path d="M312 272H536" stroke="#38BDF8" stroke-width="4" stroke-linecap="round"/>
+  <path d="M312 296H512" stroke="#38BDF8" stroke-opacity="0.5" stroke-width="4" stroke-linecap="round"/>
+  <path d="M312 320H436" stroke="#38BDF8" stroke-opacity="0.3" stroke-width="4" stroke-linecap="round"/>
+  <path d="M312 360H520" stroke="#FACC15" stroke-width="4" stroke-linecap="round"/>
+  <path d="M312 384H444" stroke="#FACC15" stroke-opacity="0.4" stroke-width="4" stroke-linecap="round"/>
+  <rect x="64" y="320" width="184" height="96" rx="20" fill="#1E293B"/>
+  <path d="M92 348H220" stroke="#38BDF8" stroke-width="4" stroke-linecap="round"/>
+  <path d="M92 372H208" stroke="#38BDF8" stroke-opacity="0.5" stroke-width="4" stroke-linecap="round"/>
+  <path d="M92 396H184" stroke="#38BDF8" stroke-opacity="0.3" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/src/app/builder/BuilderRoot.tsx
+++ b/src/app/builder/BuilderRoot.tsx
@@ -16,8 +16,8 @@ const steps: BuilderStep[] = [
   { label: "Checkout", href: "/builder/checkout" },
 ];
 
-export default async function BuilderRoot({ children }: BuilderRootProps) {
-  const templates = await loadTemplates();
+export default function BuilderRoot({ children }: BuilderRootProps) {
+  const templates = loadTemplates();
 
   return (
     <BuilderProvider templates={templates}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,31 +1,66 @@
+import Image from "next/image";
 import Link from "next/link";
 
+import { loadTemplates } from "@/lib/templates";
+
 export default function HomePage() {
+  const templates = loadTemplates();
+
   return (
-    <main className="mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center gap-8 px-4 text-center">
-      <span className="rounded-full bg-builder-surface px-4 py-1 text-sm font-medium text-slate-300">
-        Prosite Builder
-      </span>
-      <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
-        Launch your next professional website in minutes.
-      </h1>
-      <p className="max-w-2xl text-lg text-slate-300">
-        Choose a premium template, customize every detail with our intuitive builder, and publish with a
-        subscription powered by Stripe.
-      </p>
-      <div className="flex flex-wrap items-center justify-center gap-4">
-        <Link
-          className="rounded-full bg-builder-accent px-6 py-3 text-base font-semibold text-slate-900 shadow-lg shadow-sky-500/30 transition hover:brightness-110"
-          href="/builder/theme"
-        >
-          Start Building
-        </Link>
-        <Link
-          className="rounded-full border border-slate-600 px-6 py-3 text-base font-semibold text-slate-200 transition hover:border-builder-accent hover:text-builder-accent"
-          href="#"
-        >
-          Explore Templates
-        </Link>
+    <main className="mx-auto max-w-6xl px-6 py-12">
+      <section className="text-center">
+        <span className="inline-flex items-center justify-center rounded-full bg-builder-surface px-4 py-1 text-sm font-medium text-slate-300">
+          Prosite Builder
+        </span>
+        <h1 className="mt-6 text-4xl font-semibold tracking-tight text-white sm:text-5xl">
+          Choose a template to jumpstart your next website.
+        </h1>
+        <p className="mx-auto mt-4 max-w-2xl text-base text-slate-300 sm:text-lg">
+          Every template is handcrafted with flexible sections and theme controls. Pick one to start customizing, then fine-tune colors, fonts, and content in minutes.
+        </p>
+      </section>
+
+      <div className="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 xl:grid-cols-3">
+        {templates.map((template) => {
+          const previewImage = template.previewImage || "/placeholder-template.svg";
+
+          return (
+            <article
+              key={template.id}
+              className="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-800 bg-slate-900/40 shadow-lg shadow-slate-900/20 backdrop-blur transition hover:-translate-y-1 hover:shadow-xl"
+            >
+              <div className="relative aspect-[4/3] w-full overflow-hidden bg-slate-800">
+                <Image
+                  src={previewImage}
+                  alt={`${template.name} preview`}
+                  fill
+                  sizes="(min-width: 1280px) 384px, (min-width: 640px) 50vw, 100vw"
+                  className="h-full w-full object-cover"
+                />
+              </div>
+              <div className="flex flex-1 flex-col gap-3 p-6">
+                <div>
+                  <h2 className="text-xl font-semibold text-white">{template.name}</h2>
+                  <p className="mt-1 text-sm text-slate-300">{template.description}</p>
+                </div>
+                {template.sections.length > 0 && (
+                  <div className="mt-auto text-xs font-medium uppercase tracking-wide text-slate-400">
+                    Includes: {template.sections.join(", ")}
+                  </div>
+                )}
+                <div className="mt-4 flex items-center justify-between">
+                  <span className="text-xs font-medium uppercase tracking-[0.3em] text-slate-500">Template</span>
+                  <Link
+                    href={`/builder/${template.id}`}
+                    className="inline-flex items-center justify-center rounded-full bg-builder-accent px-4 py-2 text-sm font-semibold text-slate-900 transition hover:brightness-110"
+                  >
+                    Select
+                  </Link>
+                </div>
+              </div>
+            </article>
+          );
+        })}
       </div>
     </main>
   );

--- a/src/app/templates/[templateId]/route.ts
+++ b/src/app/templates/[templateId]/route.ts
@@ -9,10 +9,8 @@ export async function GET(
 ): Promise<Response> {
   try {
     const { templateId } = params;
-    const [assets, templates] = await Promise.all([
-      loadTemplateAssets(templateId),
-      loadTemplates(),
-    ]);
+    const assets = await loadTemplateAssets(templateId);
+    const templates = loadTemplates();
 
     const templateMeta = templates.find((template) => template.id === templateId);
     const placeholders = extractPlaceholders(assets.html);

--- a/templates/portfolio-creative/meta.json
+++ b/templates/portfolio-creative/meta.json
@@ -1,8 +1,8 @@
 {
   "id": "portfolio-creative",
   "name": "Portfolio Creative",
-  "description": "Bold single-page portfolio ideal for designers and agencies.",
-  "previewImage": "",
+  "description": "A bold single-page portfolio ideal for designers, agencies, and creative professionals.",
+  "previewImage": "/thumbnails/portfolio-creative.svg",
   "sections": [
     "Profile",
     "Hero",


### PR DESCRIPTION
## Summary
- add a synchronous template loader that collects metadata and paths for each template folder
- render the homepage as a responsive grid of template cards with optimized preview images
- refresh template metadata and add thumbnail assets for use across the app

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd7f6c8a808326a3a812e58a19c0ce