### PR TITLE
Support preselecting templates via query param

### DIFF
--- a/src/app/builder/templates/page.tsx
+++ b/src/app/builder/templates/page.tsx
@@ -1,9 +1,18 @@
 import { TemplateSelection } from "@/components/builder/TemplateSelection";
 
-export default function TemplateSelectionPage() {
+type TemplateSelectionPageProps = {
+  searchParams?: {
+    template?: string | string[];
+  };
+};
+
+export default function TemplateSelectionPage({ searchParams }: TemplateSelectionPageProps) {
+  const templateParam = searchParams?.template;
+  const initialTemplateId = Array.isArray(templateParam) ? templateParam[0] : templateParam;
+
   return (
     <div className="space-y-10 p-6">
-      <TemplateSelection />
+      <TemplateSelection initialTemplateId={initialTemplateId} />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,7 +51,7 @@ export default function HomePage() {
                 <div className="mt-4 flex items-center justify-between">
                   <span className="text-xs font-medium uppercase tracking-[0.3em] text-slate-500">Template</span>
                   <Link
-                    href={`/builder/${template.id}`}
+                    href={`/builder/templates?template=${template.id}`}
                     className="inline-flex items-center justify-center rounded-full bg-builder-accent px-4 py-2 text-sm font-semibold text-slate-900 transition hover:brightness-110"
                   >
                     Select

--- a/src/components/builder/TemplateSelection.tsx
+++ b/src/components/builder/TemplateSelection.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect } from "react";
+
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 
@@ -9,9 +11,25 @@ function classNames(...classes: (string | false | null | undefined)[]) {
   return classes.filter(Boolean).join(" ");
 }
 
-export function TemplateSelection() {
+type TemplateSelectionProps = {
+  initialTemplateId?: string;
+};
+
+export function TemplateSelection({ initialTemplateId }: TemplateSelectionProps) {
   const router = useRouter();
   const { templates, selectedTemplate, selectTemplate } = useBuilder();
+
+  useEffect(() => {
+    if (!initialTemplateId) {
+      return;
+    }
+
+    const hasTemplate = templates.some((template) => template.id === initialTemplateId);
+
+    if (hasTemplate) {
+      selectTemplate(initialTemplateId);
+    }
+  }, [initialTemplateId, selectTemplate, templates]);
 
   if (!templates.length) {
     return (


### PR DESCRIPTION
## Summary
- update the home page template cards to link to the builder templates step with the selected template encoded in the query string
- allow the builder templates page to read the template query parameter and pass it into the selection component
- ensure the template selection component can preselect templates by id when the builder loads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd84c4c83883268878fe573e06d86f