### PR TITLE
Implement credential-based authentication

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,5 +2,8 @@
   "extends": [
     "next/core-web-vitals",
     "next/typescript"
+  ],
+  "ignorePatterns": [
+    "next-env.d.ts"
   ]
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,11 @@
+import { withAuth } from "next-auth/middleware";
+
+export default withAuth({
+  pages: {
+    signIn: "/auth/login",
+  },
+});
+
+export const config = {
+  matcher: ["/dashboard/:path*", "/builder/:path*"],
+};

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "stripe": "^14.25.0",
+    "zod": "^3.24.1",
     "zustand": "^5.0.8"
   },
   "devDependencies": {

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,31 +1,7 @@
 import NextAuth from "next-auth";
-import Credentials from "next-auth/providers/credentials";
 
-const handler = NextAuth({
-  providers: [
-    Credentials({
-      name: "Credentials",
-      credentials: {
-        email: { label: "Email", type: "email", placeholder: "you@example.com" },
-        password: { label: "Password", type: "password" }
-      },
-      async authorize(credentials) {
-        if (!credentials?.email) {
-          return null;
-        }
+import { authOptions } from "@/lib/auth";
 
-        // TODO: replace with secure credential check via MongoDB
-        return {
-          id: "demo-user",
-          name: "Demo User",
-          email: credentials.email
-        };
-      }
-    })
-  ],
-  session: {
-    strategy: "jwt"
-  }
-});
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+import bcrypt from "bcryptjs";
+import { z } from "zod";
+
+import { connectDB } from "@/lib/db";
+import { User } from "@/models/user";
+
+const registerSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export async function POST(request: Request) {
+  try {
+    const json = await request.json();
+    const parsed = registerSchema.safeParse(json);
+
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Invalid input", details: parsed.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const { email, password } = parsed.data;
+
+    await connectDB();
+
+    const existingUser = await User.findOne({ email });
+    if (existingUser) {
+      return NextResponse.json({ error: "Email already in use" }, { status: 409 });
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    await User.create({ email, password: hashedPassword });
+
+    return NextResponse.json({ ok: true, message: "Account created" }, { status: 201 });
+  } catch (error) {
+    console.error("Register error", error);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+
+const loginSchema = z.object({
+  email: z.string().email("Please enter a valid email"),
+  password: z.string().min(1, "Password is required"),
+});
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [form, setForm] = useState({ email: "", password: "" });
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    const parsed = loginSchema.safeParse(form);
+    if (!parsed.success) {
+      const firstError = Object.values(parsed.error.flatten().fieldErrors)[0]?.[0] ?? "Invalid input";
+      setError(firstError);
+      return;
+    }
+
+    setLoading(true);
+
+    const result = await signIn("credentials", {
+      email: parsed.data.email,
+      password: parsed.data.password,
+      redirect: false,
+    });
+
+    setLoading(false);
+
+    if (result?.error) {
+      setError("Invalid email or password");
+      return;
+    }
+
+    router.push("/dashboard");
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12">
+      <div className="w-full max-w-sm rounded-lg bg-white p-8 shadow">
+        <h1 className="text-2xl font-bold text-gray-900">Sign in</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          New here? {""}
+          <Link href="/auth/register" className="font-semibold text-blue-600 hover:underline">
+            Create an account
+          </Link>
+        </p>
+
+        {error ? (
+          <p className="mt-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <form className="mt-6 space-y-4" onSubmit={handleSubmit} noValidate>
+          <div className="space-y-1">
+            <label htmlFor="email" className="text-sm font-medium text-gray-700">
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={form.email}
+              onChange={handleChange}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="password" className="text-sm font-medium text-gray-700">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              value={form.password}
+              onChange={handleChange}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded bg-blue-600 px-4 py-2 font-semibold text-white shadow hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:cursor-not-allowed disabled:opacity-75"
+          >
+            {loading ? "Signing in..." : "Sign in"}
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { z } from "zod";
+
+const registerSchema = z
+  .object({
+    email: z.string().email("Please enter a valid email"),
+    password: z.string().min(6, "Password must be at least 6 characters"),
+    confirmPassword: z.string().min(6, "Password confirmation is required"),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+export default function RegisterPage() {
+  const router = useRouter();
+  const [form, setForm] = useState({ email: "", password: "", confirmPassword: "" });
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    const parsed = registerSchema.safeParse(form);
+    if (!parsed.success) {
+      const firstError = Object.values(parsed.error.flatten().fieldErrors)[0]?.[0] ?? "Invalid input";
+      setError(firstError);
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const response = await fetch("/api/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: parsed.data.email,
+          password: parsed.data.password,
+        }),
+      });
+
+      if (!response.ok) {
+        const data = (await response.json().catch(() => null)) as { error?: string } | null;
+        setError(data?.error ?? "Unable to create account");
+        setLoading(false);
+        return;
+      }
+
+      router.push("/auth/login");
+      router.refresh();
+    } catch (err) {
+      console.error("Register request failed", err);
+      setError("Unexpected error. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12">
+      <div className="w-full max-w-sm rounded-lg bg-white p-8 shadow">
+        <h1 className="text-2xl font-bold text-gray-900">Create an account</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Already have an account? {""}
+          <Link href="/auth/login" className="font-semibold text-blue-600 hover:underline">
+            Sign in
+          </Link>
+        </p>
+
+        {error ? (
+          <p className="mt-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <form className="mt-6 space-y-4" onSubmit={handleSubmit} noValidate>
+          <div className="space-y-1">
+            <label htmlFor="email" className="text-sm font-medium text-gray-700">
+              Email
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={form.email}
+              onChange={handleChange}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="password" className="text-sm font-medium text-gray-700">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              autoComplete="new-password"
+              required
+              value={form.password}
+              onChange={handleChange}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor="confirmPassword" className="text-sm font-medium text-gray-700">
+              Confirm password
+            </label>
+            <input
+              id="confirmPassword"
+              name="confirmPassword"
+              type="password"
+              autoComplete="new-password"
+              required
+              value={form.confirmPassword}
+              onChange={handleChange}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded bg-blue-600 px-4 py-2 font-semibold text-white shadow hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:cursor-not-allowed disabled:opacity-75"
+          >
+            {loading ? "Creating account..." : "Create account"}
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,18 @@
 import type { Metadata } from "next";
 import "./globals.css";
 
+import SessionWrapper from "@/components/SessionWrapper";
+
 export const metadata: Metadata = {
   title: "Prosite Builder",
-  description: "Craft professional websites with Prosite's builder."
+  description: "Craft professional websites with Prosite's builder.",
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className="h-full bg-builder-background">
       <body className="min-h-screen bg-builder-background text-slate-100 antialiased">
-        {children}
+        <SessionWrapper>{children}</SessionWrapper>
       </body>
     </html>
   );

--- a/src/components/SessionWrapper.tsx
+++ b/src/components/SessionWrapper.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export default function SessionWrapper({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,71 @@
+import type { NextAuthOptions } from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+import bcrypt from "bcryptjs";
+import { z } from "zod";
+
+import { connectDB } from "@/lib/db";
+import { User } from "@/models/user";
+
+const credentialsSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+});
+
+export const authOptions: NextAuthOptions = {
+  session: { strategy: "jwt" },
+  providers: [
+    CredentialsProvider({
+      name: "Credentials",
+      credentials: {
+        email: { label: "Email", type: "email", placeholder: "you@example.com" },
+        password: { label: "Password", type: "password" },
+      },
+      async authorize(rawCredentials) {
+        const parsed = credentialsSchema.safeParse(rawCredentials);
+        if (!parsed.success) {
+          return null;
+        }
+
+        const { email, password } = parsed.data;
+
+        await connectDB();
+        const user = await User.findOne({ email }).lean();
+        if (!user || !user.password) {
+          return null;
+        }
+
+        const isValid = await bcrypt.compare(password, user.password);
+        if (!isValid) {
+          return null;
+        }
+
+        return {
+          id: String(user._id),
+          email: user.email,
+        };
+      },
+    }),
+  ],
+  pages: {
+    signIn: "/auth/login",
+  },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.id = (user as { id: string }).id;
+        token.email = user.email;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (token?.id) {
+        (session as typeof session & { userId?: string }).userId = token.id as string;
+      }
+      if (session.user) {
+        session.user.email = token.email as string | undefined;
+      }
+      return session;
+    },
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+};

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,0 +1,19 @@
+import { Schema, model, models, type HydratedDocument } from "mongoose";
+
+export interface IUser {
+  email: string;
+  password: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const UserSchema = new Schema<IUser>(
+  {
+    email: { type: String, unique: true, required: true },
+    password: { type: String, required: true },
+  },
+  { timestamps: true }
+);
+
+export const User = models.User || model<IUser>("User", UserSchema);
+export type UserDocument = HydratedDocument<IUser>;


### PR DESCRIPTION
## Summary
- integrate NextAuth credentials provider with MongoDB models, bcrypt password checks, and shared auth options
- add register and login flows with UI pages, validation, and API routes
- wrap the app with a session provider and protect dashboard and builder routes via middleware

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dd9558bc58832688f4e64f7de4a179