### PR TITLE
Add authenticated dashboard and navigation

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,23 @@
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+
+export default async function DashboardPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.email) {
+    redirect("/auth/login");
+  }
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 px-4 py-16">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight text-slate-100">Dashboard</h1>
+        <p className="mt-2 text-base text-slate-300">
+          Signed in as <span className="font-semibold text-white">{session.user.email}</span>.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 
+import Navbar from "@/components/Navbar";
 import SessionWrapper from "@/components/SessionWrapper";
 
 export const metadata: Metadata = {
@@ -12,7 +13,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className="h-full bg-builder-background">
       <body className="min-h-screen bg-builder-background text-slate-100 antialiased">
-        <SessionWrapper>{children}</SessionWrapper>
+        <SessionWrapper>
+          <Navbar />
+          <main>{children}</main>
+        </SessionWrapper>
       </body>
     </html>
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { signOut, useSession } from "next-auth/react";
+
+const navLinks = [
+  { href: "/dashboard", label: "Dashboard" },
+  { href: "/builder/templates", label: "Builder" },
+];
+
+function isActive(pathname: string, href: string) {
+  if (href.startsWith("/builder")) {
+    return pathname.startsWith("/builder");
+  }
+  return pathname === href;
+}
+
+export default function Navbar() {
+  const { data: session, status } = useSession();
+  const pathname = usePathname();
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-slate-800/60 bg-slate-950/80 backdrop-blur">
+      <nav className="mx-auto flex h-16 w-full max-w-6xl items-center justify-between px-4">
+        <Link href="/" className="text-lg font-semibold text-white">
+          Prosite
+        </Link>
+
+        <div className="flex items-center gap-6">
+          <div className="hidden items-center gap-4 text-sm font-medium text-slate-300 sm:flex">
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={`transition hover:text-white ${
+                  isActive(pathname, link.href) ? "text-white" : "text-slate-300"
+                }`}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+
+          {status === "loading" ? (
+            <span className="h-9 w-24 animate-pulse rounded bg-slate-800" aria-hidden />
+          ) : session ? (
+            <button
+              type="button"
+              onClick={() => {
+                void signOut({ callbackUrl: "/" });
+              }}
+              className="rounded bg-slate-800 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700"
+            >
+              Sign out
+            </button>
+          ) : (
+            <Link
+              href="/auth/login"
+              className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-500"
+            >
+              Sign in
+            </Link>
+          )}
+        </div>
+      </nav>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- add a server-rendered dashboard page that reads the NextAuth session
- wrap the root layout with the session provider and render a session-aware navbar

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddb67f8ee88326952dbf1dde85f7df