### PR TITLE
Improve register flow normalization and login link

### DIFF
--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -6,7 +6,7 @@ import { connectDB } from "@/lib/db";
 import { User } from "@/models/user";
 
 const registerSchema = z.object({
-  email: z.string().email(),
+  email: z.string().trim().email(),
   password: z.string().min(6),
 });
 
@@ -23,17 +23,18 @@ export async function POST(request: Request) {
     }
 
     const { email, password } = parsed.data;
+    const normalizedEmail = email.trim().toLowerCase();
 
     await connectDB();
 
-    const existingUser = await User.findOne({ email });
+    const existingUser = await User.findOne({ email: normalizedEmail });
     if (existingUser) {
       return NextResponse.json({ error: "Email already in use" }, { status: 409 });
     }
 
     const hashedPassword = await bcrypt.hash(password, 10);
 
-    await User.create({ email, password: hashedPassword });
+    await User.create({ email: normalizedEmail, password: hashedPassword });
 
     return NextResponse.json({ ok: true, message: "Account created" }, { status: 201 });
   } catch (error) {

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -55,13 +55,6 @@ export default function LoginPage() {
     <main className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-12">
       <div className="w-full max-w-sm rounded-lg bg-white p-8 shadow">
         <h1 className="text-2xl font-bold text-gray-900">Sign in</h1>
-        <p className="mt-2 text-sm text-gray-600">
-          New here? {""}
-          <Link href="/auth/register" className="font-semibold text-blue-600 hover:underline">
-            Create an account
-          </Link>
-        </p>
-
         {error ? (
           <p className="mt-4 rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700" role="alert">
             {error}
@@ -109,6 +102,13 @@ export default function LoginPage() {
             {loading ? "Signing in..." : "Sign in"}
           </button>
         </form>
+
+        <p className="mt-6 text-center text-sm text-gray-600">
+          Don&apos;t have an account?{' '}
+          <Link href="/auth/register" className="font-semibold text-blue-600 hover:underline">
+            Sign up
+          </Link>
+        </p>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- normalize signup emails before checking for duplicates and saving them
- move the sign-up prompt beneath the login form with updated copy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ddc283c4f08326a8262b0cfd5897e6