### PR TITLE
Add header step navigation controls for builder

### DIFF
--- a/src/app/builder/BuilderLayoutClient.tsx
+++ b/src/app/builder/BuilderLayoutClient.tsx
@@ -1,45 +1,46 @@
 "use client";
 
 import { useMemo, type ReactNode } from "react";
-import { usePathname, useRouter } from "next/navigation";
 
 import { useBuilder } from "@/context/BuilderContext";
 import { DeviceControls } from "@/components/builder/DeviceControls";
 import { ProgressBar } from "@/components/builder/ProgressBar";
 import { Sidebar } from "@/components/builder/Sidebar";
 import { WebsitePreview } from "@/components/builder/WebsitePreview";
-
-export type BuilderStep = {
-  label: string;
-  href: string;
-};
+import { StepNavigation } from "@/components/builder/StepNavigation";
 
 type BuilderLayoutClientProps = {
-  steps: BuilderStep[];
   children: ReactNode;
 };
 
-export function BuilderLayoutClient({ steps, children }: BuilderLayoutClientProps) {
-  const pathname = usePathname();
-  const router = useRouter();
-  const { isSidebarCollapsed } = useBuilder();
+export function BuilderLayoutClient({ children }: BuilderLayoutClientProps) {
+  const { isSidebarCollapsed, steps, currentStep, goToStep } = useBuilder();
 
-  const currentStep = useMemo(() => {
-    const index = steps.findIndex((step) => pathname.startsWith(step.href));
-    return index === -1 ? 0 : index;
-  }, [pathname, steps]);
+  const progressSteps = useMemo(
+    () =>
+      steps.map((step) => ({
+        key: step,
+        label: step.charAt(0).toUpperCase() + step.slice(1),
+      })),
+    [steps]
+  );
 
   return (
     <div className="flex min-h-screen flex-col bg-gray-950 text-slate-100">
       <header className="border-b border-gray-900/70 bg-gray-950/80 backdrop-blur">
-        <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-3">
-          <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-wider text-slate-400">
-            <span className="text-slate-200">Prosite Builder</span>
-            <span className="hidden text-slate-600 sm:inline">Templates • Theme • Content • Checkout</span>
+        <div className="mx-auto flex w-full max-w-6xl items-start justify-between gap-6 px-6 py-3">
+          <div className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wider text-slate-400">
+            <div className="flex items-center gap-3">
+              <span className="text-slate-200">Prosite Builder</span>
+              <span className="hidden text-slate-600 sm:inline">Theme • Content • Checkout</span>
+            </div>
           </div>
-          <DeviceControls />
+          <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:gap-3">
+            <DeviceControls />
+            <StepNavigation />
+          </div>
         </div>
-        <ProgressBar steps={steps} activeIndex={currentStep} onStepClick={(href) => router.push(href)} />
+        <ProgressBar steps={progressSteps} activeIndex={currentStep} onStepClick={goToStep} />
       </header>
       <main className="flex flex-1 overflow-hidden">
         <section
@@ -48,7 +49,7 @@ export function BuilderLayoutClient({ steps, children }: BuilderLayoutClientProp
         >
           <WebsitePreview />
         </section>
-        <Sidebar steps={steps} currentIndex={currentStep} />
+        <Sidebar />
       </main>
       <div className="sr-only" aria-hidden>
         {children}

--- a/src/app/builder/BuilderRoot.tsx
+++ b/src/app/builder/BuilderRoot.tsx
@@ -3,25 +3,18 @@ import type { ReactNode } from "react";
 import { BuilderProvider } from "@/context/BuilderContext";
 import { getTemplates } from "@/lib/templates";
 
-import { BuilderLayoutClient, type BuilderStep } from "./BuilderLayoutClient";
+import { BuilderLayoutClient } from "./BuilderLayoutClient";
 
 type BuilderRootProps = {
   children: ReactNode;
 };
-
-const steps: BuilderStep[] = [
-  { label: "Templates", href: "/builder/templates" },
-  { label: "Theme", href: "/builder/theme" },
-  { label: "Content", href: "/builder/content" },
-  { label: "Checkout", href: "/builder/checkout" },
-];
 
 export default async function BuilderRoot({ children }: BuilderRootProps) {
   const templates = await getTemplates();
 
   return (
     <BuilderProvider templates={templates}>
-      <BuilderLayoutClient steps={steps}>{children}</BuilderLayoutClient>
+      <BuilderLayoutClient>{children}</BuilderLayoutClient>
     </BuilderProvider>
   );
 }

--- a/src/components/builder/ProgressBar.tsx
+++ b/src/components/builder/ProgressBar.tsx
@@ -2,10 +2,15 @@
 
 import clsx from "clsx";
 
+type ProgressBarStep = {
+  key: string;
+  label: string;
+};
+
 type ProgressBarProps = {
-  steps: { label: string; href: string }[];
+  steps: ProgressBarStep[];
   activeIndex: number;
-  onStepClick?: (href: string) => void;
+  onStepClick?: (index: number) => void;
 };
 
 export function ProgressBar({ steps, activeIndex, onStepClick }: ProgressBarProps) {
@@ -16,10 +21,10 @@ export function ProgressBar({ steps, activeIndex, onStepClick }: ProgressBarProp
         const isCompleted = activeIndex > index;
 
         return (
-          <div key={step.href} className="flex flex-1 items-center gap-4">
+          <div key={step.key} className="flex flex-1 items-center gap-4">
             <button
               type="button"
-              onClick={() => onStepClick?.(step.href)}
+              onClick={() => onStepClick?.(index)}
               className="group flex items-center gap-3 text-left transition-colors"
             >
               <span className="relative flex h-4 w-4 items-center justify-center">

--- a/src/components/builder/Sidebar.tsx
+++ b/src/components/builder/Sidebar.tsx
@@ -1,18 +1,12 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import clsx from "clsx";
-import { useRouter } from "next/navigation";
 import { useBuilder, type TemplateContentSection } from "@/context/BuilderContext";
 import type { TemplateColorDefinition, TemplateModuleDefinition } from "@/lib/templates";
 import { PageList } from "./PageList";
 import { ThemeSelector } from "./ThemeSelector";
 import { ContentForm } from "./ContentForm";
-
-type SidebarProps = {
-  steps: { label: string; href: string }[];
-  currentIndex: number;
-};
 
 const tabs = [
   { id: "pages", label: "Pages" },
@@ -20,18 +14,13 @@ const tabs = [
   { id: "content", label: "Content" },
 ] as const;
 
-const STEP_ORDER = ["templates", "theme", "content", "checkout"] as const;
-
-type StepKey = (typeof STEP_ORDER)[number];
-
-function formatStepLabel(step: StepKey) {
+function formatStepLabel(step: string) {
   return step.charAt(0).toUpperCase() + step.slice(1);
 }
 
 type TabId = (typeof tabs)[number]["id"];
 
-export function Sidebar({ steps, currentIndex }: SidebarProps) {
-  const router = useRouter();
+export function Sidebar() {
   const {
     isSidebarCollapsed,
     toggleSidebar,
@@ -43,30 +32,12 @@ export function Sidebar({ steps, currentIndex }: SidebarProps) {
     theme,
     themeDefaults,
     updateTheme,
+    steps,
+    currentStep,
   } = useBuilder();
   const [activeTab, setActiveTab] = useState<TabId>("pages");
 
-  const currentStepLabel = useMemo(() => steps[currentIndex]?.label ?? "", [currentIndex, steps]);
-
-  const currentStepKey = STEP_ORDER[currentIndex] ?? STEP_ORDER[0];
-  const currentStepPosition = STEP_ORDER.findIndex((step) => step === currentStepKey);
-  const nextStepKey =
-    currentStepPosition >= 0 && currentStepPosition < STEP_ORDER.length - 1
-      ? STEP_ORDER[currentStepPosition + 1]
-      : undefined;
-  const nextButtonLabel =
-    currentStepKey === "checkout"
-      ? "Finish"
-      : nextStepKey
-        ? `Next: ${formatStepLabel(nextStepKey)}`
-        : "Next";
-
-  const handleNavigate = (direction: "prev" | "next") => {
-    const nextIndex = direction === "prev" ? currentIndex - 1 : currentIndex + 1;
-    if (nextIndex >= 0 && nextIndex < steps.length) {
-      router.push(steps[nextIndex].href);
-    }
-  };
+  const currentStepKey = steps[currentStep] ?? steps[0];
 
   return (
     <aside
@@ -88,7 +59,7 @@ export function Sidebar({ steps, currentIndex }: SidebarProps) {
         <div className="flex h-full flex-1 flex-col overflow-hidden">
           <div className="border-b border-gray-900/60 px-4 pb-4 pt-6">
             <p className="text-[11px] font-semibold uppercase tracking-[0.3em] text-slate-500">Inspector</p>
-            <p className="text-sm font-medium text-slate-200">{currentStepLabel || "Builder"}</p>
+            <p className="text-sm font-medium text-slate-200">{formatStepLabel(currentStepKey ?? "") || "Builder"}</p>
           </div>
 
           <div className="flex flex-1 flex-col overflow-hidden">
@@ -143,26 +114,6 @@ export function Sidebar({ steps, currentIndex }: SidebarProps) {
             </div>
           </div>
 
-          <div className="border-t border-gray-900/60 px-4 py-4">
-            <div className="flex items-center gap-3">
-              <button
-                type="button"
-                onClick={() => handleNavigate("prev")}
-                disabled={currentIndex === 0}
-                className="flex-1 rounded-full border border-gray-800 bg-gray-900 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-slate-600 hover:text-slate-100 disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                Back
-              </button>
-              <button
-                type="button"
-                onClick={() => handleNavigate("next")}
-                disabled={currentIndex === steps.length - 1}
-                className="flex-1 rounded-full bg-builder-accent px-4 py-2 text-sm font-semibold text-slate-950 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {nextButtonLabel}
-              </button>
-            </div>
-          </div>
         </div>
       ) : null}
     </aside>

--- a/src/components/builder/StepNavigation.tsx
+++ b/src/components/builder/StepNavigation.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import clsx from "clsx";
+
+import { useBuilder } from "@/context/BuilderContext";
+
+function formatStepLabel(step: string) {
+  return step.charAt(0).toUpperCase() + step.slice(1);
+}
+
+export function StepNavigation() {
+  const { steps, currentStep, nextStep, prevStep } = useBuilder();
+
+  const isFirstStep = currentStep === 0;
+  const isLastStep = currentStep === steps.length - 1;
+  const nextStepName = steps[currentStep + 1];
+  const nextLabel = isLastStep
+    ? "Finish"
+    : nextStepName
+      ? `Next: ${formatStepLabel(nextStepName)}`
+      : "Next";
+
+  return (
+    <div className="flex w-full flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-end">
+      <button
+        type="button"
+        onClick={prevStep}
+        disabled={isFirstStep}
+        className={clsx(
+          "inline-flex items-center justify-center rounded-full border px-4 py-2 text-sm font-medium transition",
+          "border-slate-700/70 bg-gray-900 text-slate-300 hover:border-slate-500 hover:text-slate-100",
+          "disabled:cursor-not-allowed disabled:opacity-40"
+        )}
+      >
+        Back
+      </button>
+      <button
+        type="button"
+        onClick={nextStep}
+        disabled={isLastStep}
+        className={clsx(
+          "inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition",
+          "bg-builder-accent text-slate-950 hover:brightness-110",
+          "disabled:cursor-not-allowed disabled:opacity-60"
+        )}
+      >
+        {nextLabel}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- track theme/content/checkout steps in the builder context with navigation helpers
- show persistent Back/Next buttons under the device controls and update the progress bar to use step state
- simplify sidebar props and rely on the shared step context

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de744fa018832682ff402bcfd85273