### PR TITLE
Simplify builder navigation to go directly to checkout

### DIFF
--- a/src/components/builder/StepNavigation.tsx
+++ b/src/components/builder/StepNavigation.tsx
@@ -1,50 +1,33 @@
 "use client";
 
-import clsx from "clsx";
-
-import { useBuilder } from "@/context/BuilderContext";
-
-function formatStepLabel(step: string) {
-  return step.charAt(0).toUpperCase() + step.slice(1);
-}
+import { useRouter } from "next/navigation";
 
 export function StepNavigation() {
-  const { steps, currentStep, nextStep, prevStep } = useBuilder();
+  const router = useRouter();
 
-  const isFirstStep = currentStep === 0;
-  const isLastStep = currentStep === steps.length - 1;
-  const nextStepName = steps[currentStep + 1];
-  const nextLabel = isLastStep
-    ? "Finish"
-    : nextStepName
-      ? `Next: ${formatStepLabel(nextStepName)}`
-      : "Next";
+  const handleBack = () => {
+    router.back();
+  };
+
+  const handleNext = () => {
+    router.push("/builder/checkout");
+  };
 
   return (
-    <div className="flex w-full flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-end">
+    <div className="flex justify-end gap-2">
       <button
         type="button"
-        onClick={prevStep}
-        disabled={isFirstStep}
-        className={clsx(
-          "inline-flex items-center justify-center rounded-full border px-4 py-2 text-sm font-medium transition",
-          "border-slate-700/70 bg-gray-900 text-slate-300 hover:border-slate-500 hover:text-slate-100",
-          "disabled:cursor-not-allowed disabled:opacity-40"
-        )}
+        onClick={handleBack}
+        className="rounded bg-gray-800 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:bg-gray-700"
       >
         Back
       </button>
       <button
         type="button"
-        onClick={nextStep}
-        disabled={isLastStep}
-        className={clsx(
-          "inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-semibold transition",
-          "bg-builder-accent text-slate-950 hover:brightness-110",
-          "disabled:cursor-not-allowed disabled:opacity-60"
-        )}
+        onClick={handleNext}
+        className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-500"
       >
-        {nextLabel}
+        Next: Checkout
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace the builder step navigation logic with simple back/next controls that route straight to checkout
- apply builder-consistent styling to the navigation buttons and ensure the next action is labeled “Next: Checkout”

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de77f99cac8326af00ccece5fb0161