### PR TITLE
Handle TemplateSelectionPage searchParams as a promise

### DIFF
--- a/src/app/builder/templates/page.tsx
+++ b/src/app/builder/templates/page.tsx
@@ -1,13 +1,14 @@
 import { TemplateSelection } from "@/components/builder/TemplateSelection";
 
 type TemplateSelectionPageProps = {
-  searchParams?: {
+  searchParams: Promise<{
     template?: string | string[];
-  };
+  }>;
 };
 
-export default function TemplateSelectionPage({ searchParams }: TemplateSelectionPageProps) {
-  const templateParam = searchParams?.template;
+export default async function TemplateSelectionPage({ searchParams }: TemplateSelectionPageProps) {
+  const params = await searchParams;
+  const templateParam = params?.template;
   const initialTemplateId = Array.isArray(templateParam) ? templateParam[0] : templateParam;
 
   return (


### PR DESCRIPTION
## Summary
- mark the TemplateSelectionPage component as async for Next.js 15 search params handling
- await the searchParams promise and normalize the template parameter before rendering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de811b24bc83268113062390df08fd