### PR TITLE
feat(stripe): add Stripe Checkout flow with session API, webhook, checkout button, and success/cancel pages

### DIFF
--- a/src/app/api/checkout/session/route.ts
+++ b/src/app/api/checkout/session/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: "2024-06-20",
+});
+
+export async function POST(req: Request) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+    }
+
+    const { plan } = (await req.json()) as { plan?: string };
+
+    const priceMap = {
+      free: "price_xxx_free",
+      pro: "price_xxx_pro",
+      agency: "price_xxx_agency",
+    } as const;
+
+    const priceId = plan && plan in priceMap ? priceMap[plan as keyof typeof priceMap] : null;
+
+    if (!priceId) {
+      return NextResponse.json({ error: "Invalid plan" }, { status: 400 });
+    }
+
+    const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000";
+
+    const checkoutSession = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      payment_method_types: ["card"],
+      customer_email: session.user.email,
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: `${appUrl}/checkout/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${appUrl}/checkout/cancel`,
+    });
+
+    return NextResponse.json({ url: checkoutSession.url });
+  } catch (err) {
+    console.error("Stripe checkout error:", err);
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
+  }
+}

--- a/src/app/api/stripe/webhook/route.ts
+++ b/src/app/api/stripe/webhook/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import Stripe from "stripe";
+
+import { connectDB } from "@/lib/mongodb";
+import { User } from "@/models/user";
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+  apiVersion: "2024-06-20",
+});
+
+export async function POST(req: Request) {
+  const body = await req.text();
+  const sig = req.headers.get("stripe-signature");
+
+  if (!sig) {
+    return NextResponse.json({ error: "Missing stripe signature" }, { status: 400 });
+  }
+
+  try {
+    const event = stripe.webhooks.constructEvent(
+      body,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET!
+    );
+
+    switch (event.type) {
+      case "checkout.session.completed": {
+        const session = event.data.object as Stripe.Checkout.Session;
+        if (!session.customer_email) {
+          break;
+        }
+        await connectDB();
+        await User.findOneAndUpdate(
+          { email: session.customer_email },
+          {
+            stripeCustomerId: session.customer as string | undefined,
+            subscriptionStatus: "active",
+          }
+        );
+        break;
+      }
+      default:
+        break;
+    }
+
+    return NextResponse.json({ received: true });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("Webhook error:", message);
+    return NextResponse.json({ error: "Webhook error" }, { status: 400 });
+  }
+}

--- a/src/app/checkout/cancel/page.tsx
+++ b/src/app/checkout/cancel/page.tsx
@@ -1,0 +1,8 @@
+export default function CancelPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <h1 className="text-2xl font-bold text-red-600">Payment Canceled ❌</h1>
+      <p className="mt-4">You have not been charged. Feel free to try again when ready.</p>
+    </div>
+  );
+}

--- a/src/app/checkout/success/page.tsx
+++ b/src/app/checkout/success/page.tsx
@@ -1,0 +1,8 @@
+export default function SuccessPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <h1 className="text-2xl font-bold text-green-600">Payment Successful ✅</h1>
+      <p className="mt-4">Your subscription is now active.</p>
+    </div>
+  );
+}

--- a/src/components/checkout/CheckoutButton.tsx
+++ b/src/components/checkout/CheckoutButton.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+
+type Plan = "pro" | "agency";
+
+type CheckoutResponse = {
+  url?: string;
+};
+
+export function CheckoutButton({ plan }: { plan: Plan }) {
+  const [loading, setLoading] = useState(false);
+
+  const handleCheckout = async () => {
+    try {
+      setLoading(true);
+      const res = await fetch("/api/checkout/session", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ plan }),
+      });
+
+      const data = (await res.json()) as CheckoutResponse;
+      if (res.ok && data.url) {
+        window.location.href = data.url;
+        return;
+      }
+
+      alert("Error starting checkout");
+    } catch (error) {
+      console.error("Checkout initiation failed:", error);
+      alert("Error starting checkout");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleCheckout}
+      disabled={loading}
+      className="px-4 py-2 bg-blue-600 text-white rounded"
+    >
+      {loading ? "Redirecting..." : `Buy ${plan} plan`}
+    </button>
+  );
+}

--- a/src/lib/mongodb.ts
+++ b/src/lib/mongodb.ts
@@ -1,0 +1,1 @@
+export { connectDB } from "./db";

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -3,6 +3,8 @@ import { Schema, model, models, type HydratedDocument } from "mongoose";
 export interface IUser {
   email: string;
   password: string;
+  stripeCustomerId?: string;
+  subscriptionStatus?: "active" | "inactive" | "canceled";
   createdAt: Date;
   updatedAt: Date;
 }
@@ -11,6 +13,12 @@ const UserSchema = new Schema<IUser>(
   {
     email: { type: String, unique: true, required: true },
     password: { type: String, required: true },
+    stripeCustomerId: { type: String },
+    subscriptionStatus: {
+      type: String,
+      enum: ["active", "inactive", "canceled"],
+      default: "inactive",
+    },
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Summary
- add a Stripe checkout session API route that validates plans and redirects authenticated users
- introduce a Stripe webhook handler that activates subscriptions and stores Stripe customer IDs on users
- extend the user model and add checkout UI components/pages for subscription success and cancellation

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de83ea26e883269d8ef4106d4d0916