### PR TITLE
Update checkout navigation to use router push

### DIFF
--- a/src/components/builder/StepNavigation.tsx
+++ b/src/components/builder/StepNavigation.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
 
 import { useBuilder } from "@/context/BuilderContext";
 import { getBuilderStepLabel } from "@/lib/builderSteps";
 
 export function StepNavigation() {
-  const { steps, currentStep, prevStep, goToStep } = useBuilder();
+  const { steps, currentStep, prevStep, goToStep, websiteId } = useBuilder();
+  const router = useRouter();
 
   const checkoutIndex = useMemo(() => steps.indexOf("checkout"), [steps]);
 
@@ -18,16 +20,21 @@ export function StepNavigation() {
 
     return {
       hasPrevious: previous,
-      canGoToCheckout: hasCheckoutStep && !onCheckoutStep,
+      canGoToCheckout: hasCheckoutStep && !onCheckoutStep && Boolean(websiteId),
       nextButtonLabel: hasCheckoutStep ? `Next: ${checkoutLabel}` : "Next",
     };
-  }, [checkoutIndex, currentStep]);
+  }, [checkoutIndex, currentStep, websiteId]);
 
   const handleNext = useCallback(() => {
     if (checkoutIndex >= 0) {
+      if (websiteId) {
+        router.push(`/checkout/${websiteId}`);
+        return;
+      }
+
       goToStep(checkoutIndex);
     }
-  }, [checkoutIndex, goToStep]);
+  }, [checkoutIndex, goToStep, router, websiteId]);
 
   return (
     <div className="flex justify-end gap-2">


### PR DESCRIPTION
## Summary
- read the builder `websiteId` and Next.js router in the step navigation component
- prevent proceeding to checkout without a website id and redirect directly to the checkout page when available

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deba10fac08326a022037020c737e7