### PR TITLE
fix: redirect all builder checkout paths to dedicated /checkout/[websiteId] route

### DIFF
--- a/src/app/builder/[websiteId]/checkout/page.tsx
+++ b/src/app/builder/[websiteId]/checkout/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function BuilderCheckoutRedirect({ params }: { params: { websiteId: string } }) {
+  redirect(`/checkout/${params.websiteId}`);
+}


### PR DESCRIPTION
## Summary
- add a redirect page for /builder/[websiteId]/checkout to send users to the new checkout route

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dec85de9ac8326ad776254359c9a03