### PR TITLE
fix: hydrate builder websiteId for checkout navigation

### DIFF
--- a/src/app/builder/BuilderLayoutClient.tsx
+++ b/src/app/builder/BuilderLayoutClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, type ReactNode } from "react";
+import { useEffect, useMemo, type ReactNode } from "react";
 
 import { useBuilder } from "@/context/BuilderContext";
 import { getBuilderStepLabel } from "@/lib/builderSteps";
@@ -9,13 +9,25 @@ import { ProgressBar } from "@/components/builder/ProgressBar";
 import { Sidebar } from "@/components/builder/Sidebar";
 import { WebsitePreview } from "@/components/builder/WebsitePreview";
 import { StepNavigation } from "@/components/builder/StepNavigation";
+import { useParams } from "next/navigation";
 
 type BuilderLayoutClientProps = {
   children: ReactNode;
 };
 
 export function BuilderLayoutClient({ children }: BuilderLayoutClientProps) {
-  const { isSidebarCollapsed, steps, currentStep, goToStep } = useBuilder();
+  const { isSidebarCollapsed, steps, currentStep, goToStep, setWebsiteId } = useBuilder();
+  const params = useParams<{ websiteId?: string }>();
+  const websiteIdFromParams =
+    typeof params?.websiteId === "string" && params.websiteId.trim().length > 0
+      ? params.websiteId.trim()
+      : undefined;
+
+  useEffect(() => {
+    if (websiteIdFromParams) {
+      setWebsiteId(websiteIdFromParams);
+    }
+  }, [setWebsiteId, websiteIdFromParams]);
 
   const progressSteps = useMemo(
     () => steps.map((step) => ({ key: step, label: getBuilderStepLabel(step) })),

--- a/src/components/builder/StepNavigation.tsx
+++ b/src/components/builder/StepNavigation.tsx
@@ -12,29 +12,32 @@ export function StepNavigation() {
 
   const checkoutIndex = useMemo(() => steps.indexOf("checkout"), [steps]);
 
-const { hasPrevious, canGoToCheckout, nextButtonLabel } = useMemo(() => {
-  const previous = currentStep > 0;
-  const checkoutLabel = getBuilderStepLabel("checkout");
-  const hasCheckoutStep = checkoutIndex >= 0;
-  const onCheckoutStep = checkoutIndex === currentStep;
+  const { hasPrevious, canGoToCheckout, nextButtonLabel } = useMemo(() => {
+    const previous = currentStep > 0;
+    const checkoutLabel = getBuilderStepLabel("checkout");
+    const hasCheckoutStep = checkoutIndex >= 0;
+    const onCheckoutStep = checkoutIndex === currentStep;
 
-  return {
-    hasPrevious: previous,
-    // ✅ allow going to checkout step without requiring websiteId immediately
-    canGoToCheckout: hasCheckoutStep && !onCheckoutStep,
-    nextButtonLabel: hasCheckoutStep ? `Next: ${checkoutLabel}` : "Next",
-  };
-}, [checkoutIndex, currentStep]);
+    return {
+      hasPrevious: previous,
+      // ✅ allow going to checkout step without requiring websiteId immediately
+      canGoToCheckout: hasCheckoutStep && !onCheckoutStep,
+      nextButtonLabel: hasCheckoutStep ? `Next: ${checkoutLabel}` : "Next",
+    };
+  }, [checkoutIndex, currentStep]);
 
 
   const handleNext = useCallback(() => {
     if (checkoutIndex >= 0) {
-      if (websiteId) {
-        router.push(`/checkout/${websiteId}`);
+      console.log("DEBUG Checkout → websiteId:", websiteId);
+
+      if (!websiteId) {
+        console.error("No websiteId found. Falling back to builder checkout step.");
+        goToStep(checkoutIndex);
         return;
       }
 
-      goToStep(checkoutIndex);
+      router.push(`/checkout/${websiteId}`);
     }
   }, [checkoutIndex, goToStep, router, websiteId]);
 


### PR DESCRIPTION
## Summary
- add websiteId state management and logging to the builder context
- hydrate the builder context with the website id from route params
- guard checkout navigation with debug logging and graceful fallback when the id is missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68deedd4313c832685a5a21ce256f2d7