### PR TITLE
fix: hydrate websiteId at template selection, use async params for checkout, and fix image warnings

### DIFF
--- a/src/app/builder/[websiteId]/checkout/page.tsx
+++ b/src/app/builder/[websiteId]/checkout/page.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 
-export default function BuilderCheckoutRedirect({ params }: { params: { websiteId: string } }) {
-  redirect(`/checkout/${params.websiteId}`);
+export default async function BuilderCheckoutRedirect({ params }: { params: Promise<{ websiteId: string }> }) {
+  const { websiteId } = await params;
+  redirect(`/checkout/${websiteId}`);
 }

--- a/src/app/checkout/[websiteId]/page.tsx
+++ b/src/app/checkout/[websiteId]/page.tsx
@@ -8,8 +8,8 @@ import { isValidObjectId } from "mongoose";
 const FALLBACK_IMAGE = "/placeholder-template.svg";
 
 type CheckoutPageProps = {
-  params: { websiteId: string };
-  searchParams?: { canceled?: string };
+  params: Promise<{ websiteId: string }>;
+  searchParams?: Promise<{ canceled?: string }>;
 };
 
 async function loadWebsite(websiteId: string) {
@@ -47,19 +47,21 @@ async function loadWebsite(websiteId: string) {
 }
 
 export default async function CheckoutPage({ params, searchParams }: CheckoutPageProps) {
-  const details = await loadWebsite(params.websiteId);
+  const { websiteId } = await params;
+  const resolvedSearchParams = searchParams ? await searchParams : undefined;
+  const details = await loadWebsite(websiteId);
 
   if (!details) {
     notFound();
   }
 
-  const initialError = searchParams?.canceled ? "Checkout canceled. You can try again when you're ready." : null;
+  const initialError = resolvedSearchParams?.canceled ? "Checkout canceled. You can try again when you're ready." : null;
 
   return (
     <main className="min-h-screen bg-slate-950 pb-16 pt-20 text-white">
       <div className="mx-auto w-full max-w-6xl px-6">
         <CheckoutClient
-          websiteId={params.websiteId}
+          websiteId={websiteId}
           websiteName={details.name}
           templateName={details.templateName}
           themeName={details.themeName}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ export default async function HomePage() {
       </section>
 
       <div className="mt-12 grid grid-cols-1 gap-8 sm:grid-cols-2 xl:grid-cols-3">
-        {templates.map((template) => {
+        {templates.map((template, index) => {
           const previewImage = template.previewImage || "/placeholder-template.svg";
 
           return (
@@ -29,11 +29,12 @@ export default async function HomePage() {
               key={template.id}
               className="flex h-full flex-col overflow-hidden rounded-2xl border border-slate-800 bg-slate-900/40 shadow-lg shadow-slate-900/20 backdrop-blur transition hover:-translate-y-1 hover:shadow-xl"
             >
-              <div className="relative aspect-[4/3] w-full overflow-hidden bg-slate-800">
+              <div className="relative h-64 w-full overflow-hidden bg-slate-800">
                 <Image
                   src={previewImage}
                   alt={`${template.name} preview`}
                   fill
+                  priority={index < 3}
                   sizes="(min-width: 1280px) 384px, (min-width: 640px) 50vw, 100vw"
                   className="h-full w-full object-cover"
                 />


### PR DESCRIPTION
## Summary
- create a website when a template is selected, hydrate the builder state, and navigate directly to the theme step
- update checkout routes to await async params and redirect safely
- ensure template thumbnail images reserve height and mark above-the-fold images as priority

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68def3fb30c48326917065af6a51e1bb