### PR TITLE
Ensure checkout navigation waits for website ID

### DIFF
--- a/src/components/builder/StepNavigation.tsx
+++ b/src/components/builder/StepNavigation.tsx
@@ -21,10 +21,11 @@ export function StepNavigation() {
     return {
       hasPrevious: previous,
       // ✅ allow going to checkout step without requiring websiteId immediately
-      canGoToCheckout: hasCheckoutStep && !onCheckoutStep,
+      canGoToCheckout:
+        hasCheckoutStep && !onCheckoutStep && Boolean(websiteId),
       nextButtonLabel: hasCheckoutStep ? `Next: ${checkoutLabel}` : "Next",
     };
-  }, [checkoutIndex, currentStep]);
+  }, [checkoutIndex, currentStep, websiteId]);
 
 
   const handleNext = useCallback(() => {


### PR DESCRIPTION
## Summary
- require a website ID before enabling the checkout navigation button
- memoize checkout navigation state changes when the website ID updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def76e377c8326be683d685682d6ff