### PR TITLE
Add website PATCH API and auto-save builder updates

### DIFF
--- a/src/app/api/websites/[id]/route.ts
+++ b/src/app/api/websites/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import { connectDB } from "@/lib/mongodb";
+import { Website } from "@/models/website";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.email) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const updates = await req.json();
+    await connectDB();
+
+    const website = await Website.findById(params.id);
+    if (!website) {
+      return NextResponse.json({ error: "Website not found" }, { status: 404 });
+    }
+
+    const sessionWithId = session as typeof session & { userId?: string };
+    if (website.userId && sessionWithId.userId && String(website.userId) !== sessionWithId.userId) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    if (updates.theme && typeof updates.theme === "object") {
+      website.theme = updates.theme;
+    }
+    if (updates.content && typeof updates.content === "object") {
+      website.content = updates.content;
+    }
+    if (Object.prototype.hasOwnProperty.call(updates, "name")) {
+      website.name = updates.name;
+    }
+
+    website.updatedAt = new Date();
+    await website.save();
+
+    return NextResponse.json(website);
+  } catch (err) {
+    console.error("Error updating website:", err);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/models/website.ts
+++ b/src/models/website.ts
@@ -24,6 +24,11 @@ const websiteSchema = new Schema(
     templateId: { type: String, required: true },
     userId: { type: Schema.Types.ObjectId, ref: "User" },
     theme: { type: themeSchema, default: undefined },
+    content: {
+      type: Map,
+      of: String,
+      default: () => new Map<string, string>(),
+    },
     thumbnailUrl: { type: String },
     previewImage: { type: String },
     status: {


### PR DESCRIPTION
## Summary
- add a PATCH endpoint for updating website records with authenticated access control
- extend the website schema to persist editable content alongside theme data
- hook builder state updates to persist theme and content changes through the new API

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68defb1324a48326bdffabfde1975c0a