### PR TITLE
Create website records on template selection

### DIFF
--- a/src/components/builder/TemplateSelection.tsx
+++ b/src/components/builder/TemplateSelection.tsx
@@ -17,6 +17,8 @@ type TemplateSelectionProps = {
 
 type CreateWebsiteResponse = {
   _id: string;
+  templateId: string;
+  status: "draft" | "published";
 };
 
 export function TemplateSelection({ initialTemplateId }: TemplateSelectionProps) {


### PR DESCRIPTION
## Summary
- add an authenticated POST /api/websites endpoint that persists new draft websites from templates
- update the template selection flow to create a website, store its MongoDB _id in context, and redirect the builder accordingly

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df029432b88326b5a8b4b33a118de6