### PR TITLE
fix: create website in DB on template selection

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,6 @@
 import Image from "next/image";
-import Link from "next/link";
-
 import { getTemplates } from "@/lib/templates";
+import { TemplateSelectButton } from "@/components/home/TemplateSelectButton";
 
 export default async function HomePage() {
   const templates = await getTemplates();
@@ -51,12 +50,12 @@ export default async function HomePage() {
                 )}
                 <div className="mt-4 flex items-center justify-between">
                   <span className="text-xs font-medium uppercase tracking-[0.3em] text-slate-500">Template</span>
-                  <Link
-                    href={`/builder/templates?template=${template.id}`}
-                    className="inline-flex items-center justify-center rounded-full bg-builder-accent px-4 py-2 text-sm font-semibold text-slate-900 transition hover:brightness-110"
+                  <TemplateSelectButton
+                    templateId={template.id}
+                    className="inline-flex items-center justify-center rounded-full bg-builder-accent px-4 py-2 text-sm font-semibold text-slate-900 transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-80"
                   >
                     Select
-                  </Link>
+                  </TemplateSelectButton>
                 </div>
               </div>
             </article>

--- a/src/components/home/TemplateSelectButton.tsx
+++ b/src/components/home/TemplateSelectButton.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState, type ReactNode } from "react";
+import { useRouter } from "next/navigation";
+
+interface TemplateSelectButtonProps {
+  templateId: string;
+  className?: string;
+  children?: ReactNode;
+}
+
+interface CreateWebsiteResponse {
+  _id: string;
+}
+
+export function TemplateSelectButton({
+  templateId,
+  className,
+  children,
+}: TemplateSelectButtonProps) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleClick = async () => {
+    if (isLoading) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const response = await fetch("/api/websites", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ templateId }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to create website (status ${response.status})`);
+      }
+
+      const website: CreateWebsiteResponse = await response.json();
+
+      if (!website?._id) {
+        throw new Error("Website response did not include an _id");
+      }
+
+      router.replace(`/builder/${website._id}/theme`);
+    } catch (error) {
+      console.error("Failed to create website", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={className}
+      disabled={isLoading}
+    >
+      {isLoading ? "Creating website..." : children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable client-side template selection button that creates a website via the API and redirects with the database id
- update the home page template cards to use the new selection flow so choosing a template immediately persists a website

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68df079497dc8326a1f6102830ec5872