### PR TITLE
feat: support free plan activation without Stripe + unify dashboard view

### DIFF
--- a/src/app/api/checkout_sessions/route.ts
+++ b/src/app/api/checkout_sessions/route.ts
@@ -28,6 +28,15 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Forbidden" }, { status: 403 });
     }
 
+    if (plan === "free") {
+      await Website.findByIdAndUpdate(websiteId, {
+        status: "active",
+        plan: "free",
+      });
+
+      return NextResponse.json({ url: `/checkout/success?websiteId=${websiteId}` });
+    }
+
     let lineItemPrice = "";
     let mode: "payment" | "subscription" = "payment";
 

--- a/src/app/checkout/[websiteId]/CheckoutClient.tsx
+++ b/src/app/checkout/[websiteId]/CheckoutClient.tsx
@@ -35,11 +35,6 @@ export function CheckoutClient({
   const handleProceed = async () => {
     if (isSubmitting) return;
 
-    if (selectedPlan === "free") {
-      window.location.href = `/dashboard?plan=free&website=${encodeURIComponent(websiteId)}`;
-      return;
-    }
-
     try {
       setIsSubmitting(true);
       setError(null);
@@ -51,7 +46,7 @@ export function CheckoutClient({
       });
 
       const data = (await res.json()) as { url?: string; error?: string };
-      if (data?.url) {
+      if (res.ok && data?.url) {
         window.location.href = data.url;
         return;
       }


### PR DESCRIPTION
## Summary
- activate free plan websites directly in the checkout session API and return the success redirect without hitting Stripe
- route all checkout plans through the same client handler so the free plan now uses the checkout session API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfe23583ec83268cc7d1948eb84e76