### PR TITLE
fix: ensure website theme defaults and safe patch updates

### DIFF
--- a/src/app/api/websites/route.ts
+++ b/src/app/api/websites/route.ts
@@ -53,6 +53,15 @@ export async function POST(request: Request) {
       user: session.user.email,
       status: "draft",
       plan: "free",
+      theme: {
+        colors: {
+          primary: "#3B82F6",
+          secondary: "#10B981",
+          background: "#FFFFFF",
+          text: "#1F2937",
+        },
+        fonts: {},
+      },
     });
 
     return NextResponse.json(website.toJSON(), { status: 201 });


### PR DESCRIPTION
## Summary
- add a default theme when creating new websites so downstream flows have real color values
- harden the website PATCH handler with logging and defensive merging for theme and content updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e00b1612fc83269e80b877b74f120d