### PR TITLE
Add authentication guard to template selection

### DIFF
--- a/src/components/home/TemplateSelectButton.tsx
+++ b/src/components/home/TemplateSelectButton.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, type ReactNode } from "react";
+import { signIn, useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 
 interface TemplateSelectButtonProps {
@@ -19,10 +20,18 @@ export function TemplateSelectButton({
   children,
 }: TemplateSelectButtonProps) {
   const router = useRouter();
+  const { data: session } = useSession();
   const [isLoading, setIsLoading] = useState(false);
 
   const handleClick = async () => {
     if (isLoading) {
+      return;
+    }
+
+    if (!session) {
+      await signIn(undefined, {
+        callbackUrl: `/builder/templates?selected=${encodeURIComponent(templateId)}`,
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary
- import session utilities from next-auth in the template selection button
- require an authenticated session before creating a new website and redirect unauthenticated users to sign in

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01eb2c0908326ae2b4f096118789d