### PR TITLE
Fix restaurant classic template asset paths

### DIFF
--- a/templates/restaurant-classic/index.html
+++ b/templates/restaurant-classic/index.html
@@ -1,6 +1,6 @@
 <body data-template-id="restaurant-classic">
-<link rel="stylesheet" href="/templates/restaurant-classic/styles.css">
-<img src="../../public/templates/restaurant-classic/assets/restaurant-hero.jpg">
+<link rel="stylesheet" href="styles.css">
+<img src="./assets/restaurant-hero.jpg">
 
 <section class="hero">
   <div class="hero__content">


### PR DESCRIPTION
## Summary
- update the restaurant classic template stylesheet link to use the relative path that gets rewritten
- change the hero image to use the same relative assets path as the rest of the template

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e15940142c83269c06f98fd53276d0