### PR TITLE
fix: ensure builder back button returns home

### DIFF
--- a/src/app/builder/BuilderLayoutClient.tsx
+++ b/src/app/builder/BuilderLayoutClient.tsx
@@ -9,6 +9,7 @@ import { ProgressBar } from "@/components/builder/ProgressBar";
 import { Sidebar } from "@/components/builder/Sidebar";
 import { WebsitePreview } from "@/components/builder/WebsitePreview";
 import { StepNavigation } from "@/components/builder/StepNavigation";
+import BackButton from "@/components/builder/BackButton";
 import { useParams } from "next/navigation";
 
 type BuilderLayoutClientProps = {
@@ -41,11 +42,14 @@ export function BuilderLayoutClient({ children }: BuilderLayoutClientProps) {
   return (
     <div className="flex min-h-screen flex-col bg-gray-950 text-slate-100">
       <header className="border-b border-gray-900/70 bg-gray-950/80 backdrop-blur">
-        <div className="mx-auto flex w-full max-w-6xl items-start justify-between gap-6 px-6 py-3">
-          <div className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wider text-slate-400">
-            <div className="flex items-center gap-3">
-              <span className="text-slate-200">Prosite Builder</span>
-              <span className="hidden text-slate-600 sm:inline">{stepSummary}</span>
+        <div className="mx-auto flex w-full max-w-6xl items-center justify-between gap-6 px-6 py-3">
+          <div className="flex items-center gap-4">
+            <BackButton />
+            <div className="flex flex-col gap-1 text-xs font-semibold uppercase tracking-wider text-slate-400">
+              <div className="flex items-center gap-3">
+                <span className="text-slate-200">Prosite Builder</span>
+                <span className="hidden text-slate-600 sm:inline">{stepSummary}</span>
+              </div>
             </div>
           </div>
           <div className="flex flex-col items-end gap-2 sm:flex-row sm:items-center sm:gap-3">

--- a/src/components/builder/BackButton.tsx
+++ b/src/components/builder/BackButton.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function BackButton() {
+  const router = useRouter();
+
+  return (
+    <button
+      type="button"
+      onClick={() => router.push("/")}
+      className="inline-flex items-center gap-2 text-sm font-semibold text-slate-400 transition hover:text-slate-200"
+      aria-label="Go back to home"
+    >
+      <span aria-hidden>←</span>
+      <span>Back</span>
+    </button>
+  );
+}

--- a/src/components/builder/StepNavigation.tsx
+++ b/src/components/builder/StepNavigation.tsx
@@ -7,26 +7,27 @@ import { useBuilder } from "@/context/BuilderContext";
 import { getBuilderStepLabel } from "@/lib/builderSteps";
 
 export function StepNavigation() {
-  const { steps, currentStep, prevStep, goToStep, websiteId } = useBuilder();
+  const { steps, currentStep, goToStep, websiteId } = useBuilder();
   const router = useRouter();
 
   const checkoutIndex = useMemo(() => steps.indexOf("checkout"), [steps]);
 
-  const { hasPrevious, canGoToCheckout, nextButtonLabel } = useMemo(() => {
-    const previous = currentStep > 0;
+  const { canGoToCheckout, nextButtonLabel } = useMemo(() => {
     const checkoutLabel = getBuilderStepLabel("checkout");
     const hasCheckoutStep = checkoutIndex >= 0;
     const onCheckoutStep = checkoutIndex === currentStep;
 
     return {
-      hasPrevious: previous,
       // ✅ allow going to checkout step without requiring websiteId immediately
       canGoToCheckout:
         hasCheckoutStep && !onCheckoutStep && Boolean(websiteId),
       nextButtonLabel: hasCheckoutStep ? `Next: ${checkoutLabel}` : "Next",
     };
   }, [checkoutIndex, currentStep, websiteId]);
-
+ 
+  const handleBack = useCallback(() => {
+    router.push("/");
+  }, [router]);
 
   const handleNext = useCallback(() => {
     if (checkoutIndex >= 0) {
@@ -46,9 +47,8 @@ export function StepNavigation() {
     <div className="flex justify-end gap-2">
       <button
         type="button"
-        onClick={prevStep}
-        disabled={!hasPrevious}
-        className="rounded bg-gray-800 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+        onClick={handleBack}
+        className="rounded bg-gray-800 px-4 py-2 text-sm font-semibold text-slate-200 transition hover:bg-gray-700"
       >
         Back
       </button>


### PR DESCRIPTION
## Summary
- add a BackButton component that always routes users to the home page
- update the builder layout header to render the new back button for consistent navigation
- update the builder step navigation back button to push users to the landing page instead of previous steps

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e28c5ecc24832698d97eba5ee5619d