### PR TITLE
Inline template CSS and fix asset paths in builder preview

### DIFF
--- a/src/app/api/templates/export/route.ts
+++ b/src/app/api/templates/export/route.ts
@@ -47,6 +47,7 @@ export async function POST(request: Request) {
       values: body.content ?? {},
       modules: template.modules,
       theme: resolveThemeColors(template, body.theme, body.themeDefaults),
+      css,
     });
 
     const finalHtml = wrapWithDocument(rendered);

--- a/src/app/templates/[templateId]/route.ts
+++ b/src/app/templates/[templateId]/route.ts
@@ -35,6 +35,7 @@ export async function GET(
         background: themeDefaults.background,
         text: themeDefaults.text,
       },
+      css: assets.css,
     });
     const document = `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8" />
 <title>${templateMeta?.name ?? "Template preview"}</title>

--- a/src/components/builder/WebsitePreview.tsx
+++ b/src/components/builder/WebsitePreview.tsx
@@ -130,7 +130,8 @@ export function WebsitePreview() {
       .filter(Boolean)
       .join(" ");
 
-    const themedCss = `:root { ${colorVariables} ${fontVariables} }\n${assets.css}`;
+    const themeTokens = [colorVariables, fontVariables].filter(Boolean).join(" ");
+    const themedCss = themeTokens ? `:root { ${themeTokens} }` : "";
 
     const rendered = renderTemplate({
       html: assets.html,
@@ -142,11 +143,14 @@ export function WebsitePreview() {
         background: colorPalette.background,
         text: colorPalette.text,
       },
+      css: assets.css,
     });
 
     const renderedWithScroll = injectScrollScript(rendered);
 
-    return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><style>${themedCss}</style></head><body>${renderedWithScroll}</body></html>`;
+    const themeStyleTag = themedCss ? `<style>${themedCss}</style>` : "";
+
+    return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" />${themeStyleTag}</head><body>${renderedWithScroll}</body></html>`;
   }, [
     assets,
     mergedData,


### PR DESCRIPTION
## Summary
- inline template CSS when rendering templates and rewrite asset URLs to absolute template paths
- pass template CSS from the builder preview and server routes so previews load without redundant stylesheet requests
- keep export packaging intact while eliminating cancelled asset requests inside the editor iframe

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2ab3fd2c4832694f72cabca982212