### PR TITLE
Add local uploads for builder image fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@
 .DS_Store
 *.log
 
+# uploaded assets
+/public/uploads
+
 # generated
 .next-env.d.ts

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { promises as fs } from "fs";
+import path from "path";
+
+export async function POST(req: Request) {
+  const formData = await req.formData();
+  const file = formData.get("file") as File | null;
+  if (!file) {
+    return NextResponse.json({ error: "No file uploaded" }, { status: 400 });
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  const uploadDir = path.join(process.cwd(), "public", "uploads");
+  await fs.mkdir(uploadDir, { recursive: true });
+
+  const ext = path.extname(file.name);
+  const base = path.basename(file.name, ext).replace(/[^a-zA-Z0-9_-]/g, "_");
+  const safeName = `${base}_${Date.now()}${ext}`;
+
+  const filePath = path.join(uploadDir, safeName);
+  await fs.writeFile(filePath, buffer);
+
+  const url = `/uploads/${safeName}`;
+  return NextResponse.json({ url });
+}


### PR DESCRIPTION
## Summary
- add a local upload API route that stores images under `public/uploads` and returns their URL
- replace builder content image inputs with file pickers that upload to the new endpoint and refresh the preview
- ignore the uploads directory so generated assets are not committed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2ddce12f48326b6c22ca7fd10543c