### PR TITLE
feat: add hover video previews and modal for templates

### DIFF
--- a/public/templates/agency-starter/preview.mp4
+++ b/public/templates/agency-starter/preview.mp4
@@ -1,0 +1,1 @@
+Placeholder video. Replace with actual MP4 preview.

--- a/public/templates/portfolio-creative/preview.mp4
+++ b/public/templates/portfolio-creative/preview.mp4
@@ -1,0 +1,1 @@
+Placeholder video. Replace with actual MP4 preview.

--- a/public/templates/restaurant-classic/preview.mp4
+++ b/public/templates/restaurant-classic/preview.mp4
@@ -1,0 +1,1 @@
+Placeholder video. Replace with actual MP4 preview.

--- a/scripts/validateTemplates.ts
+++ b/scripts/validateTemplates.ts
@@ -9,6 +9,7 @@ type TemplateMeta = {
   colors?: Record<string, string> | undefined;
   preview?: string;
   previewImage?: string;
+  video?: string;
 };
 
 const root = path.resolve("templates");
@@ -99,6 +100,17 @@ for (const folder of folders) {
     }
   } else {
     console.log(chalk.yellow(`⚠️  ${folder}: No preview image path defined in meta.json`));
+  }
+
+  const videoPath = typeof meta.video === "string" && meta.video.trim().length ? meta.video.trim() : undefined;
+  if (videoPath) {
+    const normalisedVideoPath = videoPath.replace(/^\/+/, "");
+    const absoluteVideoPath = path.join("public", normalisedVideoPath);
+    if (!fs.existsSync(absoluteVideoPath)) {
+      console.log(
+        chalk.yellow(`⚠️  ${folder}: Preview video not found at public/${normalisedVideoPath} (defined as ${videoPath})`)
+      );
+    }
   }
 
   const missingFields = uniquePlaceholders.filter((placeholder) => !fieldKeys.includes(placeholder));

--- a/src/components/builder/TemplateCard.tsx
+++ b/src/components/builder/TemplateCard.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import Image from "next/image";
+import clsx from "clsx";
+
+import { TemplatePreviewModal } from "@/components/ui/TemplatePreviewModal";
+
+export type TemplateCardTemplate = {
+  id: string;
+  name: string;
+  description: string;
+  preview?: string;
+  previewImage?: string;
+  previewVideo?: string;
+  video?: string;
+};
+
+type TemplateCardProps = {
+  template: TemplateCardTemplate;
+  onSelect: (templateId: string) => void | Promise<void>;
+  className?: string;
+};
+
+export function TemplateCard({ template, onSelect, className }: TemplateCardProps) {
+  const [isHovering, setIsHovering] = useState(false);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  const previewSrc = template.preview ?? template.previewImage;
+  const videoSrc = template.video ?? template.previewVideo;
+
+  useEffect(() => {
+    const node = videoRef.current;
+
+    if (!node || !videoSrc) {
+      return;
+    }
+
+    if (isHovering) {
+      const play = async () => {
+        try {
+          await node.play();
+        } catch (error) {
+          console.warn("Unable to autoplay preview video", error);
+        }
+      };
+
+      void play();
+      return;
+    }
+
+    node.pause();
+    try {
+      node.currentTime = 0;
+    } catch {
+      // ignore seeking issues
+    }
+  }, [isHovering, videoSrc]);
+
+  return (
+    <>
+      <div
+        onMouseEnter={() => setIsHovering(true)}
+        onMouseLeave={() => setIsHovering(false)}
+        className={clsx(
+          "group relative flex h-64 w-full cursor-pointer overflow-hidden rounded-3xl bg-gray-950/40 transition",
+          className
+        )}
+      >
+        {videoSrc ? (
+          <video
+            ref={videoRef}
+            src={videoSrc}
+            muted
+            loop
+            playsInline
+            preload="metadata"
+            poster={previewSrc}
+            className="h-full w-full object-cover transition-all duration-500 group-hover:scale-105"
+          />
+        ) : previewSrc ? (
+          <Image
+            src={previewSrc}
+            alt={template.name}
+            fill
+            sizes="(min-width: 1280px) 360px, (min-width: 768px) 300px, 100vw"
+            className="object-cover transition-all duration-500 group-hover:scale-105"
+            priority={false}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center bg-gray-950 text-xs uppercase tracking-[0.3em] text-slate-500">
+            No Preview
+          </div>
+        )}
+
+        <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+
+        {videoSrc ? (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              setPreviewOpen(true);
+            }}
+            className="absolute inset-0 flex items-center justify-center opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+            aria-label={`Preview ${template.name}`}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-12 w-12 text-white drop-shadow-lg"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path d="M8 5v14l11-7z" />
+            </svg>
+          </button>
+        ) : null}
+
+        <div className="absolute bottom-0 left-0 w-full bg-black/60 px-4 py-3">
+          <h3 className="text-sm font-semibold text-white">{template.name}</h3>
+        </div>
+      </div>
+
+      <TemplatePreviewModal
+        open={previewOpen}
+        onClose={() => setPreviewOpen(false)}
+        template={{
+          name: template.name,
+          description: template.description,
+          video: videoSrc,
+          preview: previewSrc,
+        }}
+        onUseTemplate={() => {
+          void onSelect(template.id);
+          setPreviewOpen(false);
+        }}
+      />
+    </>
+  );
+}

--- a/src/components/builder/TemplateSelection.tsx
+++ b/src/components/builder/TemplateSelection.tsx
@@ -2,11 +2,11 @@
 
 import { useEffect, useState } from "react";
 
-import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useSession, signIn } from "next-auth/react";
 
 import { useBuilder } from "@/context/BuilderContext";
+import { TemplateCard } from "./TemplateCard";
 
 function classNames(...classes: (string | false | null | undefined)[]) {
   return classes.filter(Boolean).join(" ");
@@ -107,7 +107,7 @@ export function TemplateSelection({ initialTemplateId }: TemplateSelectionProps)
       </div>
 
       <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-        {templates.map((template, index) => {
+        {templates.map((template) => {
           const isActive = template.id === selectedTemplate.id;
           const isPending = pendingTemplateId === template.id;
 
@@ -119,23 +119,15 @@ export function TemplateSelection({ initialTemplateId }: TemplateSelectionProps)
                 isActive ? "border-builder-accent/60 shadow-[0_16px_45px_-24px_rgba(14,165,233,0.6)]" : "border-gray-800/80 hover:border-builder-accent/40"
               )}
             >
-              <div className="relative h-64 w-full bg-gray-900">
-                {template.previewImage ? (
-                  <Image
-                    src={template.previewImage}
-                    alt={template.name}
-                    fill
-                    priority={index < 3}
-                    className="object-cover"
-                    sizes="(min-width: 1280px) 320px, (min-width: 768px) 260px, 100vw"
-                  />
-                ) : (
-                  <div className="absolute inset-0 flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-xs uppercase tracking-[0.3em] text-slate-500">
-                    No Preview
-                  </div>
-                )}
-                <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-gray-950/70 via-transparent to-transparent opacity-0 transition group-hover:opacity-100" />
-              </div>
+              <TemplateCard
+                template={{
+                  ...template,
+                  preview: template.previewImage,
+                  video: template.previewVideo,
+                }}
+                onSelect={handleSelectTemplate}
+                className="rounded-none"
+              />
 
               <div className="flex flex-1 flex-col gap-4 p-5">
                 <div className="space-y-2">

--- a/src/components/ui/TemplatePreviewModal.tsx
+++ b/src/components/ui/TemplatePreviewModal.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { Fragment, useEffect } from "react";
+import { Dialog, Transition } from "@headlessui/react";
+
+import Image from "next/image";
+import clsx from "clsx";
+
+type TemplatePreview = {
+  name: string;
+  description: string;
+  video?: string;
+  preview?: string;
+};
+
+type TemplatePreviewModalProps = {
+  open: boolean;
+  onClose: () => void;
+  template?: TemplatePreview;
+  onUseTemplate?: () => void;
+};
+
+export function TemplatePreviewModal({
+  open,
+  onClose,
+  template,
+  onUseTemplate,
+}: TemplatePreviewModalProps) {
+  useEffect(() => {
+    if (open) {
+      const previousOverflow = document.body.style.overflow;
+      document.body.dataset.templatePreviewModal = "open";
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.body.style.overflow = previousOverflow;
+        delete document.body.dataset.templatePreviewModal;
+      };
+    }
+
+    document.body.style.overflow = "";
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  const hasContent = Boolean(open && template);
+  const videoSrc = template?.video;
+  const previewSrc = template?.preview;
+
+  return (
+    <Transition show={hasContent} as={Fragment} appear>
+      <Dialog
+        as="div"
+        className="relative z-50"
+        onClose={() => {
+          onClose();
+        }}
+      >
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-200"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-150"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-black/80 backdrop-blur-sm" />
+        </Transition.Child>
+
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-200"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-150"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel className="relative w-full max-w-4xl overflow-hidden rounded-2xl border border-gray-800/70 bg-gray-900/95 text-left shadow-xl">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="absolute right-4 top-4 z-10 rounded-full bg-black/60 px-2 py-1 text-sm font-medium text-white transition hover:bg-black/80"
+                >
+                  ✕
+                </button>
+
+                <div className="relative h-[60vh] w-full bg-black">
+                  {videoSrc ? (
+                    <video
+                      key={videoSrc}
+                      src={videoSrc}
+                      autoPlay
+                      loop
+                      muted
+                      playsInline
+                      controls
+                      controlsList="nodownload noplaybackrate"
+                      className="h-full w-full object-cover"
+                      poster={previewSrc}
+                    />
+                  ) : previewSrc ? (
+                    <Image
+                      src={previewSrc}
+                      alt={template?.name ?? "Template preview"}
+                      fill
+                      sizes="(min-width: 1280px) 768px, 100vw"
+                      className="object-cover"
+                      priority
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center bg-gray-950 text-sm text-gray-400">
+                      Preview unavailable
+                    </div>
+                  )}
+                </div>
+
+                <div className="space-y-4 p-6">
+                  <Dialog.Title className="text-2xl font-semibold text-white">
+                    {template?.name}
+                  </Dialog.Title>
+                  <p className="text-sm leading-relaxed text-gray-300">{template?.description}</p>
+
+                  {onUseTemplate ? (
+                    <div className="pt-2">
+                      <button
+                        type="button"
+                        onClick={() => {
+                          onUseTemplate();
+                        }}
+                        className={clsx(
+                          "inline-flex items-center justify-center rounded-lg bg-blue-600 px-5 py-2 text-sm font-semibold text-white transition",
+                          "hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400"
+                        )}
+                      >
+                        Use this template
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              </Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  );
+}

--- a/src/context/BuilderContext.tsx
+++ b/src/context/BuilderContext.tsx
@@ -302,6 +302,7 @@ export function BuilderProvider({ children, templates }: BuilderProviderProps) {
         name: "No templates available",
         description: "Add template folders under /templates to get started.",
         previewImage: "",
+        previewVideo: undefined,
         path: "",
         sections: [],
         colors: [],

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -72,6 +72,7 @@ export type TemplateDefinition = {
   name: string;
   description: string;
   previewImage: string;
+  previewVideo?: string;
   path: string;
   sections: TemplateSectionDefinition[];
   colors: TemplateColorDefinition[];
@@ -90,6 +91,7 @@ type RawTemplateMeta = {
   description?: unknown;
   previewImage?: unknown;
   preview?: unknown;
+  video?: unknown;
   sections?: unknown;
   fields?: unknown;
   colors?: unknown;
@@ -189,6 +191,7 @@ async function buildTemplateDefinition(
       : typeof meta.preview === "string"
         ? meta.preview
         : "";
+  const previewVideo = typeof meta.video === "string" ? meta.video : undefined;
 
   const sectionsFromFields = normaliseFieldMap(meta.fields);
   const sections = sectionsFromFields.length ? sectionsFromFields : normaliseSections(meta.sections);
@@ -203,6 +206,7 @@ async function buildTemplateDefinition(
     name,
     description,
     previewImage,
+    previewVideo,
     path: `/templates/${folderName}`,
     sections,
     colors,

--- a/templates/agency-starter/meta.json
+++ b/templates/agency-starter/meta.json
@@ -4,6 +4,7 @@
   "category": "Business",
   "description": "Professional agency design with services, projects, testimonials, and FAQ.",
   "preview": "/templates/agency-starter/preview.png",
+  "video": "/templates/agency-starter/preview.mp4",
   "fields": {
     "seo.title": {
       "type": "text",

--- a/templates/portfolio-creative/meta.json
+++ b/templates/portfolio-creative/meta.json
@@ -3,6 +3,7 @@
   "name": "Portfolio Creative",
   "description": "A bold single-page portfolio ideal for designers, agencies, and creative professionals.",
   "previewImage": "/templates/portfolio-creative/preview.png",
+  "video": "/templates/portfolio-creative/preview.mp4",
   "sections": [
     {
       "id": "profile",

--- a/templates/restaurant-classic/meta.json
+++ b/templates/restaurant-classic/meta.json
@@ -4,6 +4,7 @@
   "category": "Food & Drink",
   "description": "Bold restaurant theme with menu grid and food imagery.",
   "preview": "/templates/restaurant-classic/preview.png",
+  "video": "/templates/restaurant-classic/preview.mp4",
   "fields": {
     "seo.title": {
       "type": "text",


### PR DESCRIPTION
## Summary
- add a reusable TemplatePreviewModal with animated transitions, media display, and selection CTA
- introduce a TemplateCard that plays preview videos on hover and opens the modal while integrating with template selection
- extend template metadata/loading to include preview videos, update validation, and add placeholder mp4 assets for each template

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2ea667ebc8326a531c12dbecee720