### PR TITLE
Route template selections through overview page

### DIFF
--- a/src/components/home/TemplateSelectButton.tsx
+++ b/src/components/home/TemplateSelectButton.tsx
@@ -10,10 +10,6 @@ interface TemplateSelectButtonProps {
   children?: ReactNode;
 }
 
-interface CreateWebsiteResponse {
-  _id: string;
-}
-
 export function TemplateSelectButton({
   templateId,
   className,
@@ -36,30 +32,7 @@ export function TemplateSelectButton({
     }
 
     setIsLoading(true);
-
-    try {
-      const response = await fetch("/api/websites", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ templateId }),
-      });
-
-      if (!response.ok) {
-        throw new Error(`Failed to create website (status ${response.status})`);
-      }
-
-      const website: CreateWebsiteResponse = await response.json();
-
-      if (!website?._id) {
-        throw new Error("Website response did not include an _id");
-      }
-
-      router.replace(`/builder/${website._id}/theme`);
-    } catch (error) {
-      console.error("Failed to create website", error);
-    } finally {
-      setIsLoading(false);
-    }
+    router.push(`/builder/templates/${templateId}`);
   };
 
   return (
@@ -69,7 +42,7 @@ export function TemplateSelectButton({
       className={className}
       disabled={isLoading}
     >
-      {isLoading ? "Creating website..." : children}
+      {isLoading ? "Opening template..." : children}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- redirect authenticated template selections to the new template overview route before customization begins
- update loading copy to reflect the new navigation flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2fdc873fc8326ab9a3eebf872e653