### PR TITLE
Add loading overlay when starting template customization

### DIFF
--- a/src/app/builder/templates/[templateId]/page.tsx
+++ b/src/app/builder/templates/[templateId]/page.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import { getServerSession } from "next-auth";
 import { notFound, redirect } from "next/navigation";
 
+import StartCustomizationForm from "@/components/ui/StartCustomizationForm";
 import { authOptions } from "@/lib/auth";
 import { connectDB } from "@/lib/mongodb";
 import { getTemplateById, getTemplates } from "@/lib/templates";
@@ -137,14 +138,7 @@ export default async function TemplateDetailsPage({ params }: TemplateDetailsPag
       ) : null}
 
       <div className="flex justify-center pt-8">
-        <form action={startCustomizing}>
-          <button
-            type="submit"
-            className="rounded-lg bg-blue-600 px-6 py-3 font-semibold text-white transition hover:bg-blue-500"
-          >
-            Start Customizing →
-          </button>
-        </form>
+        <StartCustomizationForm startCustomizing={startCustomizing} />
       </div>
     </div>
   );

--- a/src/components/ui/StartCustomizationForm.tsx
+++ b/src/components/ui/StartCustomizationForm.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useTransition, useState } from "react";
+
+export default function StartCustomizationForm({
+  startCustomizing,
+}: {
+  startCustomizing: () => Promise<void>;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const [loading, setLoading] = useState(false);
+
+  return (
+    <form
+      action={async () => {
+        setLoading(true);
+        startTransition(async () => {
+          await startCustomizing();
+        });
+      }}
+      className="relative"
+    >
+      <button
+        type="submit"
+        disabled={isPending || loading}
+        className="rounded-lg bg-blue-600 px-6 py-3 font-semibold text-white hover:bg-blue-500 transition disabled:opacity-60"
+      >
+        {loading ? "Redirecting to builder…" : "Start Customizing →"}
+      </button>
+
+      {loading && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm">
+          <div className="flex flex-col items-center gap-4">
+            <svg
+              className="h-10 w-10 animate-spin text-blue-400"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              ></circle>
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8v8H4z"
+              ></path>
+            </svg>
+            <p className="text-white text-sm font-medium">Redirecting to builder…</p>
+          </div>
+        </div>
+      )}
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add a StartCustomizationForm client component that shows a spinner overlay during redirects
- integrate the new form into the template details page to prevent duplicate submissions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2ff25f7ac8326ab552a2d084de975