### PR TITLE
feat: add graceful Template not found fallback page with navigation buttons

### DIFF
--- a/public/images/404-illustration.svg
+++ b/public/images/404-illustration.svg
@@ -1,0 +1,13 @@
+<svg width="240" height="240" viewBox="0 0 240 240" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="240" height="240" rx="32" fill="#0F172A" />
+  <path d="M120 48L168 120H72L120 48Z" fill="#2563EB" fill-opacity="0.8" />
+  <circle cx="120" cy="152" r="28" fill="#38BDF8" fill-opacity="0.8" />
+  <path d="M102 160H138" stroke="white" stroke-width="6" stroke-linecap="round" />
+  <path d="M112 108C112 101.373 117.373 96 124 96H148" stroke="#E2E8F0" stroke-width="6" stroke-linecap="round" />
+  <path d="M96 96L80 120" stroke="#E2E8F0" stroke-width="6" stroke-linecap="round" />
+  <path d="M144 96L160 120" stroke="#E2E8F0" stroke-width="6" stroke-linecap="round" />
+  <circle cx="92" cy="180" r="6" fill="#E2E8F0" />
+  <circle cx="148" cy="184" r="4" fill="#94A3B8" />
+  <circle cx="180" cy="80" r="6" fill="#38BDF8" />
+  <circle cx="60" cy="72" r="4" fill="#2563EB" />
+</svg>

--- a/src/app/builder/templates/[templateId]/not-found.tsx
+++ b/src/app/builder/templates/[templateId]/not-found.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import Image from "next/image";
+
+export default function TemplateNotFound() {
+  return (
+    <div className="flex min-h-[80vh] flex-col items-center justify-center gap-6 text-center px-6">
+      <Image
+        src="/images/404-illustration.svg"
+        alt="Template not found"
+        width={200}
+        height={200}
+        className="opacity-80"
+      />
+
+      <div className="space-y-3">
+        <h1 className="text-3xl font-semibold text-white">Template not found</h1>
+        <p className="text-slate-400 max-w-md">
+          The template you’re looking for doesn’t exist or was removed.  
+          Please go back to the templates list and choose another design.
+        </p>
+      </div>
+
+      <div className="flex gap-4">
+        <Link
+          href="/builder/templates"
+          className="rounded-lg bg-blue-600 px-5 py-2.5 font-semibold text-white hover:bg-blue-500 transition"
+        >
+          ← Back to templates
+        </Link>
+
+        <Link
+          href="/"
+          className="rounded-lg border border-slate-600 px-5 py-2.5 font-semibold text-slate-300 hover:bg-slate-800 transition"
+        >
+          Go home
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated not-found page for template detail routes with friendly messaging and navigation
- include an illustration asset displayed on the fallback screen

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e3005586f48326b6e3bd1054d15d06