### PR TITLE
fix: await dynamic route params for template details page

### DIFF
--- a/src/app/builder/templates/[templateId]/page.tsx
+++ b/src/app/builder/templates/[templateId]/page.tsx
@@ -14,11 +14,12 @@ export async function generateStaticParams() {
 }
 
 type TemplateDetailsPageProps = {
-  params: { templateId: string };
+  params: Promise<{ templateId: string }>;
 };
 
 export default async function TemplateDetailsPage({ params }: TemplateDetailsPageProps) {
-  const template = await getTemplateById(params.templateId);
+  const { templateId } = await params;
+  const template = await getTemplateById(templateId);
 
   if (!template) {
     return notFound();


### PR DESCRIPTION
## Summary
- update the template details builder page to await the resolved templateId param before usage to comply with Next.js 15 dynamic route requirements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e301b2f37c8326b0c68a12792207e7