### PR TITLE
Fix template overview routing for template selection

### DIFF
--- a/src/app/builder/templates/[templateId]/page.tsx
+++ b/src/app/builder/templates/[templateId]/page.tsx
@@ -22,7 +22,7 @@ export default async function TemplateDetailsPage({ params }: TemplateDetailsPag
   const template = await getTemplateById(templateId);
 
   if (!template) {
-    return notFound();
+    notFound();
   }
 
   const startCustomizing = async () => {

--- a/src/components/builder/TemplateSelection.tsx
+++ b/src/components/builder/TemplateSelection.tsx
@@ -16,7 +16,7 @@ type TemplateSelectionProps = {
 };
 
 export function TemplateSelection({ initialTemplateId }: TemplateSelectionProps) {
-  const { templates, selectedTemplate, selectTemplate } = useBuilder();
+  const { templates, selectedTemplate } = useBuilder();
   const router = useRouter();
 
   const [isGalleryOpen, setIsGalleryOpen] = useState(false);
@@ -43,9 +43,10 @@ export function TemplateSelection({ initialTemplateId }: TemplateSelectionProps)
   };
 
   const handleSelectTemplate = (templateId: string) => {
-    selectTemplate(templateId);
-    router.push(`/builder/templates/${templateId}`); // ✅ redirect to overview page
+    router.push(`/builder/templates/${templateId}`);
   };
+
+  const activeTemplateId = initialTemplateId ?? selectedTemplate?.id;
 
   const handlePreview = (templateId: string) => openGallery(templateId);
 
@@ -70,7 +71,7 @@ export function TemplateSelection({ initialTemplateId }: TemplateSelectionProps)
 
       <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
         {templates.map((template) => {
-          const isActive = template.id === selectedTemplate.id;
+          const isActive = template.id === activeTemplateId;
 
           return (
             <div


### PR DESCRIPTION
## Summary
- ensure the template overview page awaits the dynamic route params before loading data and keeps creation logic in the start customizing action
- update the template selection handler to route to the overview page and compute the active template from the initial selection

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e30e0977588326bdfc8eb995cf2413