### PR TITLE
Move template overview to standalone templates route

### DIFF
--- a/src/app/templates/[templateId]/not-found.tsx
+++ b/src/app/templates/[templateId]/not-found.tsx
@@ -22,7 +22,7 @@ export default function TemplateNotFound() {
 
       <div className="flex gap-4">
         <Link
-          href="/builder/templates"
+          href="/templates"
           className="rounded-lg bg-blue-600 px-5 py-2.5 font-semibold text-white hover:bg-blue-500 transition"
         >
           ← Back to templates

--- a/src/app/templates/[templateId]/page.tsx
+++ b/src/app/templates/[templateId]/page.tsx
@@ -31,7 +31,7 @@ export default async function TemplateDetailsPage({ params }: TemplateDetailsPag
     const session = await getServerSession(authOptions);
 
     if (!session?.user?.email) {
-      const callbackUrl = encodeURIComponent(`/builder/templates/${template.id}`);
+      const callbackUrl = encodeURIComponent(`/templates/${template.id}`);
       redirect(`/api/auth/signin?callbackUrl=${callbackUrl}`);
     }
 

--- a/src/app/templates/layout.tsx
+++ b/src/app/templates/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export default function TemplatesLayout({ children }: { children: ReactNode }) {
+  return (
+    <main className="min-h-screen bg-slate-950 text-white">
+      {children}
+    </main>
+  );
+}

--- a/src/components/builder/TemplateSelection.tsx
+++ b/src/components/builder/TemplateSelection.tsx
@@ -43,7 +43,7 @@ export function TemplateSelection({ initialTemplateId }: TemplateSelectionProps)
   };
 
   const handleSelectTemplate = (templateId: string) => {
-    router.push(`/builder/templates/${templateId}`);
+    router.push(`/templates/${templateId}`);
   };
 
   const activeTemplateId = initialTemplateId ?? selectedTemplate?.id;

--- a/src/components/home/TemplateSelectButton.tsx
+++ b/src/components/home/TemplateSelectButton.tsx
@@ -26,13 +26,13 @@ export function TemplateSelectButton({
 
     if (!session) {
       await signIn(undefined, {
-        callbackUrl: `/builder/templates?selected=${encodeURIComponent(templateId)}`,
+        callbackUrl: `/templates?selected=${encodeURIComponent(templateId)}`,
       });
       return;
     }
 
     setIsLoading(true);
-    router.push(`/builder/templates/${templateId}`);
+    router.push(`/templates/${templateId}`);
   };
 
   return (


### PR DESCRIPTION
## Summary
- relocate the template overview route to /templates/[templateId] with updated auth callback
- update template selection buttons to link to the new standalone templates path
- add a lightweight /templates layout for consistent standalone styling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e313c259548326bc9228ef58b07efe