### PR TITLE
Fix template preview metadata and safeguards

### DIFF
--- a/src/app/templates/[templateId]/page.tsx
+++ b/src/app/templates/[templateId]/page.tsx
@@ -82,21 +82,28 @@ export default async function TemplateDetailsPage({ params }: TemplateDetailsPag
             src={template.previewVideo}
             controls
             playsInline
-            poster={template.previewImage}
+            poster={template.previewImage || ""}
             className="h-[480px] w-full object-cover"
           />
-        ) : (
+        ) : null}
+        {!template.previewVideo ? (
           <div className="relative h-[480px] w-full">
-            <Image
-              src={template.previewImage}
-              alt={template.name}
-              fill
-              sizes="(min-width: 1280px) 960px, (min-width: 768px) 720px, 100vw"
-              className="object-cover"
-              priority
-            />
+            {template.previewImage ? (
+              <Image
+                src={template.previewImage}
+                alt={template.name || "Template preview"}
+                fill
+                sizes="(min-width: 1280px) 960px, (min-width: 768px) 720px, 100vw"
+                className="object-cover"
+                priority
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-gray-800 text-slate-400">
+                <p>No preview available</p>
+              </div>
+            )}
           </div>
-        )}
+        ) : null}
       </div>
 
       {template.previewImages?.length ? (

--- a/templates/agency-starter/meta.json
+++ b/templates/agency-starter/meta.json
@@ -3,9 +3,8 @@
   "name": "Agency Starter",
   "category": "Business",
   "description": "Professional agency design with services, projects, testimonials, and FAQ.",
-  "video": "/templates/agency-starter/preview.mp4",
   "previewImage": "/templates/agency-starter/preview.png",
-  "preview": "/templates/agency-starter/preview.png",
+  "previewVideo": "/templates/agency-starter/preview.mp4",
   "previewImages": [
     "/templates/agency-starter/preview.png",
     "/templates/agency-starter/assets/agency-hero.jpg",

--- a/templates/portfolio-creative/meta.json
+++ b/templates/portfolio-creative/meta.json
@@ -4,11 +4,9 @@
   "category": "Portfolio",
   "description": "A bold single-page portfolio ideal for designers, agencies, and creative professionals.",
   "previewImage": "/templates/portfolio-creative/preview.png",
-  "video": "/templates/portfolio-creative/preview.mp4",
+  "previewVideo": "/templates/portfolio-creative/preview.mp4",
   "previewImages": [
-    "/templates/portfolio-creative/preview.png",
-    "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1600&q=80",
-    "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80"
+    "/templates/portfolio-creative/preview.png"
   ],
   "features": [
     "Project case study spotlight",

--- a/templates/restaurant-classic/meta.json
+++ b/templates/restaurant-classic/meta.json
@@ -3,9 +3,8 @@
   "name": "Restaurant Classic",
   "category": "Food & Drink",
   "description": "Bold restaurant theme with menu grid and food imagery.",
-  "video": "/templates/restaurant-classic/preview.mp4",
   "previewImage": "/templates/restaurant-classic/preview.png",
-  "preview": "/templates/restaurant-classic/preview.png",
+  "previewVideo": "/templates/restaurant-classic/preview.mp4",
   "previewImages": [
     "/templates/restaurant-classic/preview.png",
     "/templates/restaurant-classic/assets/restaurant-hero.jpg",


### PR DESCRIPTION
## Summary
- ensure agency, restaurant, and portfolio template metadata use /templates-relative preview image and video paths
- add consistent previewVideo fields and clean up preview image lists across template meta files
- guard template detail page media rendering to handle missing preview images or videos gracefully

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3bd1742b48326ad5bf4338d1118b2