### PR TITLE
feat: integrate UploadThing media uploads for admin templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "react-dom": "^19.1.1",
     "stripe": "^14.25.0",
     "zod": "^3.25.76",
-    "zustand": "^5.0.8"
+    "zustand": "^5.0.8",
+    "uploadthing": "^7.0.0",
+    "@uploadthing/react": "^6.7.2",
+    "@uploadthing/shared": "^6.7.2"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",

--- a/src/app/admin/templates/new/page.tsx
+++ b/src/app/admin/templates/new/page.tsx
@@ -1,16 +1,122 @@
-import { TemplateForm } from "../_components/TemplateForm";
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { UploadButton } from "@uploadthing/react";
+
+import { useUploadThing } from "@/lib/uploadthing";
 
 export default function NewTemplatePage() {
+  const router = useRouter();
+  const { isUploading } = useUploadThing("templateMedia");
+  const [form, setForm] = useState({
+    name: "",
+    category: "",
+    description: "",
+    previewImage: "",
+    previewVideo: "",
+    previewImages: [] as string[],
+    features: "",
+  });
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    await fetch("/api/admin/templates", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...form,
+        features: form.features.split(",").map((f) => f.trim()),
+      }),
+    });
+    router.push("/admin/templates");
+  }
+
   return (
-    <div className="space-y-6">
+    <form onSubmit={handleSubmit} className="max-w-3xl space-y-6">
+      <h2 className="text-2xl font-semibold mb-2">Add New Template</h2>
+
+      <input
+        placeholder="Name"
+        value={form.name}
+        onChange={(e) => setForm({ ...form, name: e.target.value })}
+        className="w-full bg-gray-900 border border-gray-700 p-2 rounded-md"
+      />
+
+      <input
+        placeholder="Category"
+        value={form.category}
+        onChange={(e) => setForm({ ...form, category: e.target.value })}
+        className="w-full bg-gray-900 border border-gray-700 p-2 rounded-md"
+      />
+
+      <textarea
+        placeholder="Description"
+        value={form.description}
+        onChange={(e) => setForm({ ...form, description: e.target.value })}
+        className="w-full bg-gray-900 border border-gray-700 p-2 rounded-md"
+      />
+
+      {/* Upload Preview Image */}
       <div>
-        <h2 className="text-xl font-semibold text-white">Add New Template</h2>
-        <p className="text-sm text-slate-400">
-          Provide template details, media, and publishing status. All fields can be updated later.
-        </p>
+        <p className="text-sm text-slate-400 mb-1">Preview Image</p>
+        <UploadButton
+          endpoint="templateMedia"
+          onClientUploadComplete={(res) => {
+            setForm({ ...form, previewImage: res?.[0]?.url || "" });
+          }}
+          onUploadError={(err) => alert(err.message)}
+        />
+        {form.previewImage && <img src={form.previewImage} alt="Preview" className="mt-2 w-64 rounded-md" />}
       </div>
 
-      <TemplateForm mode="create" />
-    </div>
+      {/* Upload Preview Video */}
+      <div>
+        <p className="text-sm text-slate-400 mb-1">Preview Video (optional)</p>
+        <UploadButton
+          endpoint="templateMedia"
+          onClientUploadComplete={(res) => {
+            setForm({ ...form, previewVideo: res?.[0]?.url || "" });
+          }}
+          onUploadError={(err) => alert(err.message)}
+        />
+        {form.previewVideo && (
+          <video src={form.previewVideo} controls className="mt-2 w-64 rounded-md" />
+        )}
+      </div>
+
+      {/* Upload Gallery Images */}
+      <div>
+        <p className="text-sm text-slate-400 mb-1">Gallery Images</p>
+        <UploadButton
+          endpoint="templateMedia"
+          onClientUploadComplete={(res) => {
+            const urls = res?.map((f) => f.url) || [];
+            setForm({ ...form, previewImages: [...form.previewImages, ...urls] });
+          }}
+          onUploadError={(err) => alert(err.message)}
+        />
+        <div className="mt-2 grid grid-cols-3 gap-2">
+          {form.previewImages.map((img, i) => (
+            <img key={i} src={img} alt={`Preview ${i}`} className="rounded-md" />
+          ))}
+        </div>
+      </div>
+
+      <input
+        placeholder="Features (comma-separated)"
+        value={form.features}
+        onChange={(e) => setForm({ ...form, features: e.target.value })}
+        className="w-full bg-gray-900 border border-gray-700 p-2 rounded-md"
+      />
+
+      {isUploading && <p className="text-sm text-blue-400">Uploading media...</p>}
+
+      <button
+        type="submit"
+        className="mt-4 bg-blue-600 px-4 py-2 rounded-md text-white hover:bg-blue-500"
+      >
+        Save Template
+      </button>
+    </form>
   );
 }

--- a/src/app/api/uploadthing/core.ts
+++ b/src/app/api/uploadthing/core.ts
@@ -1,0 +1,21 @@
+import { createUploadthing, type FileRouter } from "uploadthing/next";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+
+const f = createUploadthing();
+
+export const ourFileRouter = {
+  templateMedia: f({ image: { maxFileSize: "8MB" }, video: { maxFileSize: "50MB" } })
+    .middleware(async () => {
+      const session = await getServerSession(authOptions);
+      if (!session) throw new Error("Unauthorized");
+      return { userId: session.user?.email || "unknown" };
+    })
+    .onUploadComplete(({ file, metadata }) => {
+      console.log("Uploaded file", file.url);
+      return { uploadedBy: metadata.userId, url: file.url };
+    }),
+} satisfies FileRouter;
+
+export type OurFileRouter = typeof ourFileRouter;

--- a/src/app/api/uploadthing/route.ts
+++ b/src/app/api/uploadthing/route.ts
@@ -1,0 +1,7 @@
+import { createNextRouteHandler } from "uploadthing/next";
+
+import { ourFileRouter } from "./core";
+
+export const { GET, POST } = createNextRouteHandler({
+  router: ourFileRouter,
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,12 @@
 import type { Metadata } from "next";
 import "./globals.css";
 
+import { NextSSRPlugin } from "@uploadthing/react/next-ssr-plugin";
+import { extractRouterConfig } from "uploadthing/server";
+
 import Navbar from "@/components/Navbar";
 import SessionWrapper from "@/components/SessionWrapper";
+import { ourFileRouter } from "@/app/api/uploadthing/core";
 
 export const metadata: Metadata = {
   title: "Prosite Builder",
@@ -13,6 +17,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className="h-full bg-builder-background">
       <body className="min-h-screen bg-builder-background text-slate-100 antialiased">
+        <NextSSRPlugin routerConfig={extractRouterConfig(ourFileRouter)} />
         <SessionWrapper>
           <Navbar />
           <main>{children}</main>

--- a/src/lib/uploadthing.ts
+++ b/src/lib/uploadthing.ts
@@ -1,0 +1,5 @@
+import { generateReactHelpers } from "@uploadthing/react/hooks";
+
+import type { OurFileRouter } from "@/app/api/uploadthing/core";
+
+export const { useUploadThing, uploadFiles } = generateReactHelpers<OurFileRouter>();


### PR DESCRIPTION
## Summary
- add UploadThing server route and client helpers for authenticated template media uploads
- update admin template creation form to support image, video, and gallery uploads with previews
- wrap the root layout with the UploadThing SSR plugin and register new dependencies

## Testing
- not run (uploadthing packages could not be installed in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e3d264f5a88326a6503c73125efad1