### PR TITLE
Allow template upload endpoint to accept video files

### DIFF
--- a/src/app/api/uploadthing/core.ts
+++ b/src/app/api/uploadthing/core.ts
@@ -6,7 +6,10 @@ import { authOptions } from "@/lib/auth";
 const f = createUploadthing();
 
 export const ourFileRouter = {
-  templateAssets: f({ image: { maxFileSize: "8MB" } })
+  templateAssets: f({
+    image: { maxFileSize: "8MB" },
+    video: { maxFileSize: "64MB" },
+  })
     .middleware(async () => {
       const session = await getServerSession(authOptions);
       if (!session?.user) throw new Error("Unauthorized");


### PR DESCRIPTION
## Summary
- allow the `templateAssets` UploadThing endpoint to accept both images and videos so preview video uploads no longer fail

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3e716039c8326b1ae99911be6c1e4