### PR TITLE
Fix builder new route ID handling

### DIFF
--- a/src/app/api/websites/[id]/route.ts
+++ b/src/app/api/websites/[id]/route.ts
@@ -4,6 +4,7 @@ import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 import { connectDB } from "@/lib/mongodb";
 import { Website } from "@/models/website";
+import { isValidObjectId } from "mongoose";
 
 export async function GET(
   _req: Request,
@@ -11,6 +12,9 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
+    if (!isValidObjectId(id)) {
+      return NextResponse.json({ error: "Invalid website ID" }, { status: 400 });
+    }
     await connectDB();
     const website = await Website.findById(id);
     if (!website) {
@@ -44,6 +48,9 @@ export async function PATCH(
     }
 
     const { id } = await params;
+    if (!isValidObjectId(id)) {
+      return NextResponse.json({ error: "Invalid website ID" }, { status: 400 });
+    }
     const updates = (await req.json()) as {
       theme?: ThemeUpdatePayload;
       content?: Record<string, string> | Map<string, string>;
@@ -135,6 +142,9 @@ export async function DELETE(
   { params }: { params: Promise<{ id: string }> }
 ) {
   const { id } = await params;
+  if (!isValidObjectId(id)) {
+    return NextResponse.json({ error: "Invalid website ID" }, { status: 400 });
+  }
   const session = await getServerSession(authOptions);
 
   if (!session?.user?.email) {

--- a/src/app/templates/[templateId]/page.tsx
+++ b/src/app/templates/[templateId]/page.tsx
@@ -32,7 +32,7 @@ export default async function TemplatePage({ params }: { params: Promise<{ templ
 
           <div className="flex justify-center gap-4">
             <Link
-              href={`/builder/new?template=${(template as any).slug || template.id}`}
+              href={`/builder/new?template=${template.slug ?? template.id}`}
               className="px-6 py-3 bg-blue-600 hover:bg-blue-500 rounded-md text-white font-medium"
             >
               Use this Template

--- a/src/lib/builderSteps.ts
+++ b/src/lib/builderSteps.ts
@@ -34,8 +34,14 @@ export function resolveBuilderBasePath(pathname: string | null | undefined) {
 
   const maybeWebsiteId = segments[1];
 
-  if (maybeWebsiteId && !isBuilderStep(maybeWebsiteId)) {
-    return { basePath: `/builder/${maybeWebsiteId}`, websiteId: maybeWebsiteId };
+  if (maybeWebsiteId) {
+    if (maybeWebsiteId === "new") {
+      return { basePath: "/builder/new", websiteId: undefined };
+    }
+
+    if (!isBuilderStep(maybeWebsiteId)) {
+      return { basePath: `/builder/${maybeWebsiteId}`, websiteId: maybeWebsiteId };
+    }
   }
 
   return { basePath: "/builder", websiteId: undefined as string | undefined };

--- a/src/lib/templates.ts
+++ b/src/lib/templates.ts
@@ -71,6 +71,7 @@ export type TemplateModuleDefinition = {
 
 export type TemplateDefinition = {
   id: string;
+  slug?: string;
   name: string;
   category?: string;
   description: string;
@@ -213,6 +214,7 @@ function buildDatabaseTemplateDefinition(template: DatabaseTemplateDocument): Dy
 
   return {
     id: slug,
+    slug,
     name,
     category: category ?? undefined,
     description,
@@ -410,6 +412,7 @@ async function buildTemplateDefinition(
 
   return {
     id,
+    slug: id,
     name,
     category,
     description,


### PR DESCRIPTION
## Summary
- prevent the builder context from treating `/builder/new` as an existing website id
- validate website ids in the website API handlers to avoid ObjectId cast errors
- expose a typed optional slug on template definitions and use it when linking to the builder

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e5620cf6788326bd23f040609b2531