### PR TITLE
Add custom builder panels and array content rendering

### DIFF
--- a/src/app/api/templates/[templateId]/route.ts
+++ b/src/app/api/templates/[templateId]/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { getTemplateAssets, getTemplates } from "@/lib/templates";
-import { applyThemeTokens, renderTemplate } from "@/lib/renderTemplate";
+import { injectThemeTokens, renderTemplate } from "@/lib/renderTemplate";
 
 export async function GET(
   request: Request,
@@ -57,7 +57,7 @@ export async function GET(
       },
     });
 
-    const document = applyThemeTokens({
+    const document = injectThemeTokens({
       html: rendered,
       css: assets.css,
       templateId,

--- a/src/app/api/websites/[id]/route.ts
+++ b/src/app/api/websites/[id]/route.ts
@@ -15,13 +15,15 @@ export async function GET(
     if (!isValidObjectId(id)) {
       return NextResponse.json({ error: "Invalid website ID" }, { status: 400 });
     }
+
     await connectDB();
-    const website = await Website.findById(id);
+    const website = await Website.findById(id).lean();
     if (!website) {
       return NextResponse.json({ error: "Website not found" }, { status: 404 });
     }
 
-    return NextResponse.json(website);
+    const payload = { ...website, _id: website._id?.toString() };
+    return NextResponse.json(payload);
   } catch (err) {
     console.error("GET error:", err);
     return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });

--- a/src/components/builder/ContentForm.tsx
+++ b/src/components/builder/ContentForm.tsx
@@ -10,7 +10,7 @@ const inputBaseClass =
 
 export type ContentFormProps = {
   section: TemplateContentSection;
-  values: Record<string, string>;
+  values: Record<string, unknown>;
   onChange: (key: string, value: string) => void;
 };
 
@@ -18,10 +18,25 @@ export function ContentForm({ section, values, onChange }: ContentFormProps) {
   return (
     <form className="space-y-4" onSubmit={(event) => event.preventDefault()}>
       {section.fields.map((field) => (
-        <Fragment key={field.key}>{renderField(field, values[field.key] ?? "", onChange)}</Fragment>
+        <Fragment key={field.key}>
+          {renderField(field, toInputValue(values[field.key]), onChange)}
+        </Fragment>
       ))}
     </form>
   );
+}
+
+function toInputValue(value: unknown): string {
+  if (value == null) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "";
 }
 
 function renderField(

--- a/src/components/builder/WebsitePreview.tsx
+++ b/src/components/builder/WebsitePreview.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useBuilder } from "@/context/BuilderContext";
-import { applyThemeTokens, renderTemplate } from "@/lib/renderTemplate";
+import { injectThemeTokens, renderTemplate } from "@/lib/renderTemplate";
 
 const DEVICE_WIDTHS = {
   desktop: 1440,
@@ -140,7 +140,7 @@ export function WebsitePreview() {
       },
     });
 
-    const themedDocument = applyThemeTokens({
+    const themedDocument = injectThemeTokens({
       html: rendered,
       css: assets.css,
       templateId: selectedTemplate.id,

--- a/src/components/builder/panels/DynamicPanels.tsx
+++ b/src/components/builder/panels/DynamicPanels.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useBuilder } from "@/context/BuilderContext";
+import type { BuilderPanel } from "@/lib/templates";
+
+import { ImageGridPanel } from "./ImageGridPanel";
+import { TableEditorPanel } from "./TableEditorPanel";
+import { TextListPanel } from "./TextListPanel";
+
+export function DynamicPanelsTabs() {
+  const { selectedTemplate } = useBuilder();
+  const panels = useMemo(() => {
+    const customPanels = (selectedTemplate as unknown as { meta?: { builder?: { customPanels?: BuilderPanel[] } } })?.meta?.builder
+      ?.customPanels;
+    if (!Array.isArray(customPanels)) {
+      return [] as BuilderPanel[];
+    }
+    return customPanels;
+  }, [selectedTemplate]);
+
+  if (!panels.length) {
+    return null;
+  }
+
+  // This component currently acts as a discovery helper; actual tab rendering happens in Sidebar.
+  return null;
+}
+
+export function DynamicPanelRenderer({ panel }: { panel: BuilderPanel }) {
+  switch (panel.type) {
+    case "image-grid":
+      return <ImageGridPanel panel={panel} />;
+    case "table-editor":
+      return <TableEditorPanel panel={panel} />;
+    case "text-list":
+      return <TextListPanel panel={panel} />;
+    default:
+      return <p className="text-slate-400">Unsupported panel type: {panel.type}</p>;
+  }
+}
+
+export function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-700 bg-slate-900 p-4">
+      <h3 className="mb-3 text-sm font-semibold text-white">{title}</h3>
+      {children}
+    </div>
+  );
+}

--- a/src/components/builder/panels/ImageGridPanel.tsx
+++ b/src/components/builder/panels/ImageGridPanel.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useBuilder } from "@/context/BuilderContext";
+import type { BuilderPanel } from "@/lib/templates";
+
+export function ImageGridPanel({ panel }: { panel: BuilderPanel }) {
+  const { content, updateContent } = useBuilder();
+  const key = panel.storageKey;
+  const initial = Array.isArray(content[key]) ? (content[key] as string[]) : [];
+  const [images, setImages] = useState<string[]>(initial);
+
+  useEffect(() => {
+    if (!Array.isArray(content[key])) {
+      return;
+    }
+    setImages(content[key] as string[]);
+  }, [content, key]);
+
+  const limit = panel.limit ?? 12;
+
+  function addImage(url: string) {
+    const next = [...images, url].slice(0, limit);
+    setImages(next);
+    updateContent({ [key]: next });
+  }
+
+  function removeImage(index: number) {
+    const next = images.filter((_, i) => i !== index);
+    setImages(next);
+    updateContent({ [key]: next });
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        <input
+          className="flex-1 rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white"
+          placeholder="Paste image URL and press Add"
+          id={`imgUrl-${key}`}
+          type="url"
+        />
+        <button
+          className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+          onClick={() => {
+            const el = document.getElementById(`imgUrl-${key}`) as HTMLInputElement | null;
+            if (el && el.value.trim()) {
+              addImage(el.value.trim());
+              el.value = "";
+            }
+          }}
+          type="button"
+        >
+          Add
+        </button>
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        {images.map((src, i) => (
+          <div key={`${src}-${i}`} className="relative">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={src} alt={`img-${i}`} className="h-24 w-full rounded-md object-cover" />
+            <button
+              className="absolute right-1 top-1 rounded bg-black/60 px-2 py-1 text-xs text-white"
+              onClick={() => removeImage(i)}
+              type="button"
+            >
+              ✕
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/builder/panels/TableEditorPanel.tsx
+++ b/src/components/builder/panels/TableEditorPanel.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { useBuilder } from "@/context/BuilderContext";
+import type { BuilderPanel } from "@/lib/templates";
+
+export function TableEditorPanel({ panel }: { panel: BuilderPanel }) {
+  const { content, updateContent } = useBuilder();
+  const key = panel.storageKey;
+  const columns = useMemo(() => panel.fields ?? ["name", "price", "description"], [panel.fields]);
+  const initial = Array.isArray(content[key]) ? (content[key] as Record<string, string>[]) : [];
+  const [rows, setRows] = useState<Record<string, string>[]>(initial);
+
+  useEffect(() => {
+    if (!Array.isArray(content[key])) {
+      return;
+    }
+    const serialised = (content[key] as unknown[]).map((row) => ({
+      ...columns.reduce((acc, col) => {
+        const value = (row as Record<string, unknown>)[col];
+        acc[col] = typeof value === "string" ? value : "";
+        return acc;
+      }, {} as Record<string, string>),
+    }));
+    setRows(serialised);
+  }, [columns, content, key]);
+
+  function addRow() {
+    const empty: Record<string, string> = {};
+    columns.forEach((c) => {
+      empty[c] = "";
+    });
+    const next = [...rows, empty];
+    setRows(next);
+    updateContent({ [key]: next });
+  }
+
+  function removeRow(index: number) {
+    const next = rows.filter((_, i) => i !== index);
+    setRows(next);
+    updateContent({ [key]: next });
+  }
+
+  function updateCell(index: number, col: string, value: string) {
+    const next = rows.map((row, i) => (i === index ? { ...row, [col]: value } : row));
+    setRows(next);
+    updateContent({ [key]: next });
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-auto rounded-md border border-slate-700">
+        <table className="min-w-full text-sm text-slate-200">
+          <thead className="bg-slate-800">
+            <tr>
+              {columns.map((c) => (
+                <th key={c} className="px-3 py-2 text-left font-semibold capitalize">
+                  {c}
+                </th>
+              ))}
+              <th className="px-3 py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr key={i} className="odd:bg-slate-900 even:bg-slate-950">
+                {columns.map((c) => (
+                  <td key={c} className="px-3 py-2">
+                    <input
+                      className="w-full rounded-md border border-slate-700 bg-slate-900 px-2 py-1 text-sm text-white"
+                      value={row[c] ?? ""}
+                      onChange={(event) => updateCell(i, c, event.target.value)}
+                    />
+                  </td>
+                ))}
+                <td className="px-3 py-2 text-right">
+                  <button
+                    className="rounded bg-red-600 px-2 py-1 text-xs text-white hover:bg-red-500"
+                    onClick={() => removeRow(i)}
+                    type="button"
+                  >
+                    Delete
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <button
+        className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+        onClick={addRow}
+        type="button"
+      >
+        Add Row
+      </button>
+    </div>
+  );
+}

--- a/src/components/builder/panels/TextListPanel.tsx
+++ b/src/components/builder/panels/TextListPanel.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useBuilder } from "@/context/BuilderContext";
+import type { BuilderPanel } from "@/lib/templates";
+
+export function TextListPanel({ panel }: { panel: BuilderPanel }) {
+  const { content, updateContent } = useBuilder();
+  const key = panel.storageKey;
+  const initial = Array.isArray(content[key]) ? (content[key] as string[]) : [];
+  const [items, setItems] = useState<string[]>(initial);
+
+  useEffect(() => {
+    if (!Array.isArray(content[key])) {
+      return;
+    }
+    setItems(content[key] as string[]);
+  }, [content, key]);
+
+  const limit = panel.limit ?? 20;
+
+  function addItem(value: string) {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+    const next = [...items, trimmed].slice(0, limit);
+    setItems(next);
+    updateContent({ [key]: next });
+  }
+
+  function removeItem(index: number) {
+    const next = items.filter((_, i) => i !== index);
+    setItems(next);
+    updateContent({ [key]: next });
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        <input
+          className="flex-1 rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white"
+          placeholder="Type item and press Add"
+          id={`text-${key}`}
+        />
+        <button
+          className="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+          onClick={() => {
+            const el = document.getElementById(`text-${key}`) as HTMLInputElement | null;
+            if (el) {
+              addItem(el.value);
+              el.value = "";
+            }
+          }}
+          type="button"
+        >
+          Add
+        </button>
+      </div>
+      <ul className="space-y-2">
+        {items.map((t, i) => (
+          <li
+            key={`${t}-${i}`}
+            className="flex items-center justify-between rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-white"
+          >
+            <span>{t}</span>
+            <button
+              className="rounded bg-red-600 px-2 py-1 text-xs text-white hover:bg-red-500"
+              onClick={() => removeItem(i)}
+              type="button"
+            >
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend template metadata types to support template-defined custom builder panels and expose strongly typed builder panels
- add reusable dynamic panel components and wire custom panel tabs into the builder sidebar with array-friendly content state
- enhance the render pipeline to support #each content blocks, theme token helpers, and lean website loading for hydrated previews

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e57e92aa5c83268dc47196d49aa844