### PR TITLE
Fix builder defaults and preview rendering

### DIFF
--- a/src/app/api/websites/route.ts
+++ b/src/app/api/websites/route.ts
@@ -118,6 +118,7 @@ export async function POST(request: Request) {
       meta: parsedMeta,
       theme: metaTheme,
       content: metaContent,
+      pages: ["Home"],
     });
 
     return NextResponse.json(website, { status: 201 });

--- a/src/components/builder/PageList.tsx
+++ b/src/components/builder/PageList.tsx
@@ -40,6 +40,23 @@ export function PageList({ pages = [] }: PageListProps) {
     [previewFrame]
   );
 
+  if (!pagesToRender.length) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-500">
+          <span>Pages</span>
+          <button
+            type="button"
+            className="text-[10px] font-semibold text-slate-500 transition hover:text-slate-300"
+          >
+            Manage
+          </button>
+        </div>
+        <p className="text-slate-400 text-sm px-3">No pages yet.</p>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-slate-500">
@@ -52,20 +69,16 @@ export function PageList({ pages = [] }: PageListProps) {
         </button>
       </div>
       <div className="flex gap-2 overflow-x-auto pb-2">
-        {pagesToRender.length > 0 ? (
-          pagesToRender.map((page) => (
-            <button
-              type="button"
-              key={page.id}
-              onClick={() => handleNavigate(page)}
-              className="whitespace-nowrap rounded-full border border-gray-800 bg-gray-950/70 px-3 py-1.5 text-xs font-medium text-slate-200 transition hover:border-builder-accent/60 hover:text-white"
-            >
-              {page.label}
-            </button>
-          ))
-        ) : (
-          <p className="px-2 text-sm text-slate-400">No pages yet.</p>
-        )}
+        {pagesToRender.map((page) => (
+          <button
+            type="button"
+            key={page.id}
+            onClick={() => handleNavigate(page)}
+            className="whitespace-nowrap rounded-full border border-gray-800 bg-gray-950/70 px-3 py-1.5 text-xs font-medium text-slate-200 transition hover:border-builder-accent/60 hover:text-white"
+          >
+            {page.label}
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/components/builder/WebsitePreview.tsx
+++ b/src/components/builder/WebsitePreview.tsx
@@ -167,22 +167,6 @@ export function WebsitePreview() {
     updatePreviewDocument(previewDocument);
   }, [previewDocument, updatePreviewDocument]);
 
-  useEffect(() => {
-    if (!previewDocument) {
-      return;
-    }
-
-    const frame = iframeRef.current;
-    const doc = frame?.contentDocument;
-    if (!frame || !doc) {
-      return;
-    }
-
-    doc.open();
-    doc.write(previewDocument);
-    doc.close();
-  }, [previewDocument, selectedTemplate.id]);
-
   const handleZoomIn = useCallback(() => {
     setIsAutoFit(false);
     setZoom((current) => {
@@ -380,15 +364,16 @@ export function WebsitePreview() {
                     </div>
                   </div>
                   <iframe
-                    key={`${selectedTemplate.id}-${device}`}
                     ref={setIframeRef}
                     id="preview-frame"
                     title="Website preview"
                     data-preview-frame="true"
-                    className="w-full border-0 bg-white"
+                    className="w-full border-0 bg-white transition-all duration-300"
                     style={{
                       height: `${currentHeight}px`
                     }}
+                    srcDoc={previewDocument}
+                    sandbox="allow-same-origin allow-scripts"
                   />
                 </div>
               </div>

--- a/src/context/BuilderContext.tsx
+++ b/src/context/BuilderContext.tsx
@@ -12,7 +12,11 @@ import {
 import { usePathname, useRouter } from "next/navigation";
 
 import type { TemplateDefinition } from "@/lib/templates";
-import { useBuilderStore, type BuilderDevice } from "@/store/builderStore";
+import {
+  DEFAULT_BUILDER_PAGES,
+  useBuilderStore,
+  type BuilderDevice,
+} from "@/store/builderStore";
 
 type Device = BuilderDevice;
 
@@ -339,7 +343,7 @@ export function BuilderProvider({ children, templates }: BuilderProviderProps) {
         ? section.label.trim()
         : toSentence(section.id)
     );
-    setStorePages(sectionLabels);
+    setStorePages(sectionLabels.length > 0 ? sectionLabels : [...DEFAULT_BUILDER_PAGES]);
   }, [selectedTemplate, setStorePages]);
 
   const websiteNameForStore = useMemo(() => {

--- a/src/lib/renderTemplate.ts
+++ b/src/lib/renderTemplate.ts
@@ -204,6 +204,18 @@ function formatScalar(value: unknown, keyPath: string) {
   if (value == null) {
     return `[${keyPath}]`;
   }
+  if (Array.isArray(value)) {
+    const markup = value
+      .map((item) => (typeof item === "string" ? item.trim() : ""))
+      .filter((item) => item.length > 0)
+      .map(
+        (url) =>
+          `<img src="${escapeAttribute(url)}" alt="gallery" style="max-width:100%;border-radius:8px;margin-bottom:8px;" />`
+      )
+      .join("");
+
+    return markup || `[${keyPath}]`;
+  }
   if (typeof value === "string") {
     return value.trim().length > 0 ? value : `[${keyPath}]`;
   }
@@ -264,6 +276,25 @@ function resolvePath(obj: unknown, path: string): unknown {
   }
 
   return current;
+}
+
+function escapeAttribute(value: string) {
+  return value.replace(/[&"'<>]/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      default:
+        return char;
+    }
+  });
 }
 
 export function composePreviewDocument(

--- a/src/store/builderStore.ts
+++ b/src/store/builderStore.ts
@@ -4,7 +4,7 @@ import { create } from "zustand";
 
 export type BuilderDevice = "desktop" | "tablet" | "mobile";
 
-const DEFAULT_PAGE_NAMES = ["Home", "About", "Contact"] as const;
+const DEFAULT_PAGE_NAMES = ["Home"] as const;
 
 type BuilderStoreState = {
   websiteId: string | null;
@@ -15,21 +15,9 @@ type BuilderStoreState = {
   setWebsiteId: (websiteId: string | null | undefined) => void;
   setWebsiteName: (websiteName: string | null | undefined) => void;
   setThemeName: (themeName: string | null | undefined) => void;
-  setPages: (pages: Array<string | null | undefined> | null | undefined) => void;
+  setPages: (pages: string[] | null | undefined) => void;
   setDevice: (device: BuilderDevice) => void;
 };
-
-function normalizePages(pages: Array<string | null | undefined> | null | undefined) {
-  if (!Array.isArray(pages)) {
-    return [...DEFAULT_PAGE_NAMES];
-  }
-
-  const normalized = pages
-    .map((page) => (typeof page === "string" ? page.trim() : ""))
-    .filter((page) => page.length > 0);
-
-  return normalized.length > 0 ? Array.from(new Set(normalized)) : [...DEFAULT_PAGE_NAMES];
-}
 
 export const useBuilderStore = create<BuilderStoreState>((set) => ({
   websiteId: null,
@@ -49,7 +37,8 @@ export const useBuilderStore = create<BuilderStoreState>((set) => ({
     set({ themeName: resolved.length > 0 ? resolved : "Default" });
   },
   setPages: (pages) => {
-    set({ pages: normalizePages(pages) });
+    const nextPages = Array.isArray(pages) && pages.length > 0 ? pages : [...DEFAULT_PAGE_NAMES];
+    set({ pages: nextPages });
   },
   setDevice: (device) => {
     set({ device });


### PR DESCRIPTION
## Summary
- ensure the builder store and provider hydrate a default "Home" page when templates or payloads omit sections
- add safe fallbacks for the page list and API website creation while supporting gallery arrays in template rendering
- keep the preview iframe mounted across device switches to prevent blank states

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e6831d5ca08326a37ea5ecec68ff16