### PR TITLE
Include websiteId in checkout success redirect

### DIFF
--- a/src/app/api/checkout_sessions/route.ts
+++ b/src/app/api/checkout_sessions/route.ts
@@ -131,7 +131,7 @@ export async function POST(req: Request) {
       mode: "subscription",
       payment_method_types: ["card"],
       line_items: [{ price: priceId, quantity: 1 }],
-      success_url: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard?success=true`,
+      success_url: `${process.env.NEXT_PUBLIC_APP_URL}/checkout/success?websiteId=${encodeURIComponent(websiteId)}`,
       cancel_url: `${process.env.NEXT_PUBLIC_APP_URL}/checkout/${websiteId}?canceled=true`,
       metadata: { websiteId, planId, billingCycle },
     });

--- a/src/app/checkout/success/page.tsx
+++ b/src/app/checkout/success/page.tsx
@@ -1,21 +1,28 @@
 "use client";
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 
 export default function SuccessPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const websiteId = searchParams.get("websiteId");
 
   useEffect(() => {
+    const destination = websiteId ? `/dashboard/${websiteId}` : "/dashboard";
     const timer = setTimeout(() => {
-      router.push("/dashboard");
+      router.push(destination);
     }, 2500);
     return () => clearTimeout(timer);
-  }, [router]);
+  }, [router, websiteId]);
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen">
       <h1 className="text-2xl font-bold text-green-600">✅ Payment Successful</h1>
-      <p className="mt-4">Redirecting you to your dashboard...</p>
+      <p className="mt-4">
+        {websiteId
+          ? "Redirecting you to your website dashboard..."
+          : "We couldn't find your website. Redirecting you to your dashboard..."}
+      </p>
 
     </div>
   );


### PR DESCRIPTION
## Summary
- add the websiteId to the Stripe checkout session success URL so the success page can target a specific dashboard
- update the checkout success page to read the query parameter, redirect to the website dashboard when present, and show a fallback message when missing

## Testing
- pnpm lint *(fails: pre-existing lint errors about `any` usage and other warnings)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f846460108326a9831dd247ac3507)