### PR TITLE
Adjust preview plan labels on dashboard

### DIFF
--- a/src/app/dashboard/[websiteId]/page.tsx
+++ b/src/app/dashboard/[websiteId]/page.tsx
@@ -25,6 +25,22 @@ function formatDateTime(value: unknown) {
   }).format(date);
 }
 
+function formatPlanLabel(plan: unknown, status: string): string {
+  const normalizedStatus = status.trim().toLowerCase();
+  const normalizedPlan =
+    typeof plan === "string" ? plan.trim() : plan ? String(plan).trim() : "";
+  const planIsFree =
+    !normalizedPlan || normalizedPlan.toLowerCase() === "free";
+
+  if (normalizedStatus === "preview" && planIsFree) {
+    return "Preview";
+  }
+
+  if (!normalizedPlan) return "Free";
+
+  return normalizedPlan.charAt(0).toUpperCase() + normalizedPlan.slice(1);
+}
+
 /* ---------- main page ---------- */
 export default async function DashboardWebsitePage({
   params,
@@ -62,13 +78,16 @@ export default async function DashboardWebsitePage({
   const seoLastScan = formatDateTime(seo.lastScan);
 
   const siteName = website.name?.trim() || "Untitled Website";
-  const sitePlan = website.plan || "Free";
   const billingCycle =
     typeof website.billingCycle === "string"
       ? website.billingCycle.charAt(0).toUpperCase() +
         website.billingCycle.slice(1)
       : null;
-  const siteStatus = website.status || "preview";
+  const siteStatus =
+    typeof website.status === "string" && website.status.length > 0
+      ? website.status
+      : "preview";
+  const sitePlan = formatPlanLabel(website.plan, siteStatus);
   const siteSubdomain = website.subdomain || websiteId.slice(-6);
 
   const hasLiveSite = Boolean(deploymentUrl);
@@ -98,9 +117,10 @@ export default async function DashboardWebsitePage({
           <p className="mt-3 text-lg font-semibold text-gray-900">{siteStatus}</p>
           <p className="mt-1 text-sm text-gray-500">
             Plan: {sitePlan}
-            {billingCycle && (
-              <span className="text-gray-400"> · {billingCycle}</span>
-            )}
+            {billingCycle &&
+              siteStatus.trim().toLowerCase() !== "preview" && (
+                <span className="text-gray-400"> · {billingCycle}</span>
+              )}
           </p>
           {lastDeployed && (
             <p className="mt-2 text-sm text-gray-400">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,6 +14,21 @@ interface DashboardSite {
   status: string;
 }
 
+function formatPlanLabel(plan: string | undefined, status: string): string {
+  const normalizedStatus = status.trim().toLowerCase();
+  const normalizedPlan = plan?.trim() ?? "";
+  const planIsFree =
+    !normalizedPlan || normalizedPlan.toLowerCase() === "free";
+
+  if (normalizedStatus === "preview" && planIsFree) {
+    return "Preview";
+  }
+
+  if (!normalizedPlan) return "Free";
+
+  return normalizedPlan.charAt(0).toUpperCase() + normalizedPlan.slice(1);
+}
+
 function toDashboardSite(value: unknown): DashboardSite | null {
   if (!value || typeof value !== "object") return null;
 
@@ -33,11 +48,6 @@ function toDashboardSite(value: unknown): DashboardSite | null {
       ? record.name
       : "Untitled Website";
 
-  const plan =
-    typeof record.plan === "string" && record.plan.length > 0
-      ? record.plan.charAt(0).toUpperCase() + record.plan.slice(1)
-      : "Free";
-
   const billingCycle =
     typeof record.billingCycle === "string" && record.billingCycle.length > 0
       ? record.billingCycle.charAt(0).toUpperCase() + record.billingCycle.slice(1)
@@ -47,6 +57,11 @@ function toDashboardSite(value: unknown): DashboardSite | null {
     typeof record.status === "string" && record.status.length > 0
       ? record.status
       : "preview";
+
+  const plan = formatPlanLabel(
+    typeof record.plan === "string" ? record.plan : undefined,
+    status,
+  );
 
   return { id, name, plan, billingCycle, status };
 }
@@ -94,9 +109,12 @@ export default async function DashboardPage() {
                 <div className="mt-1 flex flex-wrap items-center gap-3 text-sm text-gray-500">
                   <span className="rounded-full bg-blue-50 px-3 py-1 text-blue-700">
                     Plan: {site.plan}
-                    {site.billingCycle && (
-                      <span className="text-gray-400"> · {site.billingCycle}</span>
-                    )}
+                    {site.billingCycle &&
+                      site.status.trim().toLowerCase() !== "preview" && (
+                        <span className="text-gray-400">
+                          {" "}· {site.billingCycle}
+                        </span>
+                      )}
                   </span>
                   <StatusBadge status={site.status} />
                 </div>


### PR DESCRIPTION
## Summary
- ensure preview sites show a dedicated Preview plan label instead of Free on the main dashboard
- suppress billing cycle text for preview listings so the badge stays clean
- mirror the preview plan labeling on the per-site dashboard view for consistency

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f93d0625c8326aeba839837ad24f2)